### PR TITLE
Add helpers for configuring global parameters

### DIFF
--- a/inc/TMC9660.hpp
+++ b/inc/TMC9660.hpp
@@ -2756,6 +2756,120 @@ public:
   } heartbeat{*this};
 
   //***************************************************************************
+  //**                   SUBSYSTEM: Global Parameter Access                **//
+  //***************************************************************************
+  /**
+   * @brief Convenience helpers for reading and writing global parameters.
+   *
+   * The TMC9660 groups non-motion parameters into banks. This subsystem
+   * provides simple wrappers to access them using the enum classes defined in
+   * `tmc9660_param_mode_tmcl.hpp`.
+   */
+  struct Globals {
+    /// Write a value to bank 0 (system settings).
+    bool writeBank0(tmc9660::tmcl::GlobalParamBank0 param,
+                    uint32_t value) noexcept;
+
+    /// Read a value from bank 0 (system settings).
+    bool readBank0(tmc9660::tmcl::GlobalParamBank0 param,
+                   uint32_t &value) noexcept;
+
+    /// Write a signed user variable in bank 2.
+    bool writeBank2(tmc9660::tmcl::GlobalParamBank2 param,
+                    int32_t value) noexcept;
+
+    /// Read a signed user variable from bank 2.
+    bool readBank2(tmc9660::tmcl::GlobalParamBank2 param,
+                   int32_t &value) noexcept;
+
+    /// Write a value to bank 3 (interrupt configuration).
+    bool writeBank3(tmc9660::tmcl::GlobalParamBank3 param,
+                    uint32_t value) noexcept;
+
+    /// Read a value from bank 3 (interrupt configuration).
+    bool readBank3(tmc9660::tmcl::GlobalParamBank3 param,
+                   uint32_t &value) noexcept;
+
+    // High level helpers --------------------------------------------------
+    /// Set module serial address (bank0:SERIAL_ADDRESS).
+    bool setSerialAddress(uint8_t address) noexcept;
+
+    /// Get module serial address (bank0:SERIAL_ADDRESS).
+    bool getSerialAddress(uint8_t &address) noexcept;
+
+    /// Set host serial address (bank0:SERIAL_HOST_ADDRESS).
+    bool setHostAddress(uint8_t address) noexcept;
+
+    /// Get host serial address (bank0:SERIAL_HOST_ADDRESS).
+    bool getHostAddress(uint8_t &address) noexcept;
+
+    /// Configure heartbeat monitoring interface and timeout.
+    bool configureHeartbeat(
+        tmc9660::tmcl::HeartbeatMonitoringConfig iface,
+        uint32_t timeout_ms) noexcept;
+
+    /// Read heartbeat monitoring configuration.
+    bool getHeartbeat(
+        tmc9660::tmcl::HeartbeatMonitoringConfig &iface,
+        uint32_t &timeout_ms) noexcept;
+
+    /// Set GPIO direction mask (bank0:IO_DIRECTION_MASK).
+    bool setIODirectionMask(uint32_t mask) noexcept;
+
+    /// Get GPIO direction mask (bank0:IO_DIRECTION_MASK).
+    bool getIODirectionMask(uint32_t &mask) noexcept;
+
+    /// Set pull-up/down enable mask (bank0:IO_INPUT_PULLUP_PULLDOWN_ENABLE_MASK).
+    bool setPullEnableMask(uint32_t mask) noexcept;
+
+    /// Get pull-up/down enable mask.
+    bool getPullEnableMask(uint32_t &mask) noexcept;
+
+    /// Set pull direction mask (bank0:IO_INPUT_PULLUP_PULLDOWN_DIRECTION_MASK).
+    bool setPullDirectionMask(uint32_t mask) noexcept;
+
+    /// Get pull direction mask.
+    bool getPullDirectionMask(uint32_t &mask) noexcept;
+
+    /// Enable or disable auto-start of stored program (bank0:AUTO_START_ENABLE).
+    bool setAutoStart(bool enable) noexcept;
+
+    /// Read auto-start enable flag.
+    bool getAutoStart(bool &enable) noexcept;
+
+    /// Configure clearing of user variables on startup (bank0:CLEAR_USER_VARIABLES).
+    bool setClearUserVariables(bool clear) noexcept;
+
+    /// Get clear-user-variable flag.
+    bool getClearUserVariables(bool &clear) noexcept;
+
+    /// Set user variable by index (bank2).
+    bool setUserVariable(uint8_t index, int32_t value) noexcept;
+
+    /// Read user variable by index (bank2).
+    bool getUserVariable(uint8_t index, int32_t &value) noexcept;
+
+    /// Set interrupt timer period (bank3).
+    bool setTimerPeriod(uint8_t timer, uint32_t period_ms) noexcept;
+
+    /// Get interrupt timer period (bank3).
+    bool getTimerPeriod(uint8_t timer, uint32_t &period_ms) noexcept;
+
+    /// Set trigger transition for digital input n (bank3 INPUT_n_TRIGGER_TRANSITION).
+    bool setInputTrigger(uint8_t index,
+                         tmc9660::tmcl::TriggerTransition transition) noexcept;
+
+    /// Get trigger transition for digital input n.
+    bool getInputTrigger(uint8_t index,
+                         tmc9660::tmcl::TriggerTransition &transition) noexcept;
+
+  private:
+    friend class TMC9660;
+    explicit Globals(TMC9660 &parent) noexcept : driver(parent) {}
+    TMC9660 &driver;
+  } globals{*this};
+
+  //***************************************************************************
   //**        SUBSYSTEM: General-purpose GPIO (Digital/Analog I/O) **//
   //***************************************************************************
   /**

--- a/src/TMC9660.cpp
+++ b/src/TMC9660.cpp
@@ -865,4 +865,233 @@ bool TMC9660::IIT::getSum2(uint32_t &sum) noexcept {
   return driver.readGlobalParameter(tmc9660::tmcl::Parameters::IIT_SUM_2, 0,
                                     sum);
 }
+
+//-------------------------------------------------------------------------
+// Global parameter helpers
+//-------------------------------------------------------------------------
+
+bool TMC9660::Globals::writeBank0(tmc9660::tmcl::GlobalParamBank0 param,
+                                  uint32_t value) noexcept {
+  return driver.writeGlobalParameter(static_cast<uint16_t>(param), 0, value);
+}
+
+bool TMC9660::Globals::readBank0(tmc9660::tmcl::GlobalParamBank0 param,
+                                 uint32_t &value) noexcept {
+  return driver.readGlobalParameter(static_cast<uint16_t>(param), 0, value);
+}
+
+bool TMC9660::Globals::writeBank2(tmc9660::tmcl::GlobalParamBank2 param,
+                                  int32_t value) noexcept {
+  return driver.writeGlobalParameter(static_cast<uint16_t>(param), 2,
+                                     static_cast<uint32_t>(value));
+}
+
+bool TMC9660::Globals::readBank2(tmc9660::tmcl::GlobalParamBank2 param,
+                                 int32_t &value) noexcept {
+  uint32_t tmp;
+  if (!driver.readGlobalParameter(static_cast<uint16_t>(param), 2, tmp))
+    return false;
+  value = static_cast<int32_t>(tmp);
+  return true;
+}
+
+bool TMC9660::Globals::writeBank3(tmc9660::tmcl::GlobalParamBank3 param,
+                                  uint32_t value) noexcept {
+  return driver.writeGlobalParameter(static_cast<uint16_t>(param), 3, value);
+}
+
+bool TMC9660::Globals::readBank3(tmc9660::tmcl::GlobalParamBank3 param,
+                                 uint32_t &value) noexcept {
+  return driver.readGlobalParameter(static_cast<uint16_t>(param), 3, value);
+}
+
+//-------------------------------------------------------------------------
+// High level global parameter helpers
+//-------------------------------------------------------------------------
+
+bool TMC9660::Globals::setSerialAddress(uint8_t address) noexcept {
+  return writeBank0(tmc9660::tmcl::GlobalParamBank0::SERIAL_ADDRESS, address);
+}
+
+bool TMC9660::Globals::getSerialAddress(uint8_t &address) noexcept {
+  uint32_t tmp;
+  if (!readBank0(tmc9660::tmcl::GlobalParamBank0::SERIAL_ADDRESS, tmp))
+    return false;
+  address = static_cast<uint8_t>(tmp);
+  return true;
+}
+
+bool TMC9660::Globals::setHostAddress(uint8_t address) noexcept {
+  return writeBank0(tmc9660::tmcl::GlobalParamBank0::SERIAL_HOST_ADDRESS,
+                    address);
+}
+
+bool TMC9660::Globals::getHostAddress(uint8_t &address) noexcept {
+  uint32_t tmp;
+  if (!readBank0(tmc9660::tmcl::GlobalParamBank0::SERIAL_HOST_ADDRESS, tmp))
+    return false;
+  address = static_cast<uint8_t>(tmp);
+  return true;
+}
+
+bool TMC9660::Globals::configureHeartbeat(
+    tmc9660::tmcl::HeartbeatMonitoringConfig iface,
+    uint32_t timeout_ms) noexcept {
+  bool ok = writeBank0(
+      tmc9660::tmcl::GlobalParamBank0::HEARTBEAT_MONITORING_CONFIG,
+      static_cast<uint32_t>(iface));
+  ok &=
+      writeBank0(tmc9660::tmcl::GlobalParamBank0::HEARTBEAT_MONITORING_TIMEOUT,
+                 timeout_ms);
+  return ok;
+}
+
+bool TMC9660::Globals::getHeartbeat(
+    tmc9660::tmcl::HeartbeatMonitoringConfig &iface,
+    uint32_t &timeout_ms) noexcept {
+  uint32_t cfg;
+  bool ok = readBank0(
+      tmc9660::tmcl::GlobalParamBank0::HEARTBEAT_MONITORING_CONFIG, cfg);
+  iface = static_cast<tmc9660::tmcl::HeartbeatMonitoringConfig>(cfg);
+  ok &= readBank0(
+      tmc9660::tmcl::GlobalParamBank0::HEARTBEAT_MONITORING_TIMEOUT,
+      timeout_ms);
+  return ok;
+}
+
+bool TMC9660::Globals::setIODirectionMask(uint32_t mask) noexcept {
+  return writeBank0(tmc9660::tmcl::GlobalParamBank0::IO_DIRECTION_MASK, mask);
+}
+
+bool TMC9660::Globals::getIODirectionMask(uint32_t &mask) noexcept {
+  return readBank0(tmc9660::tmcl::GlobalParamBank0::IO_DIRECTION_MASK, mask);
+}
+
+bool TMC9660::Globals::setPullEnableMask(uint32_t mask) noexcept {
+  return writeBank0(
+      tmc9660::tmcl::GlobalParamBank0::IO_INPUT_PULLUP_PULLDOWN_ENABLE_MASK,
+      mask);
+}
+
+bool TMC9660::Globals::getPullEnableMask(uint32_t &mask) noexcept {
+  return readBank0(
+      tmc9660::tmcl::GlobalParamBank0::IO_INPUT_PULLUP_PULLDOWN_ENABLE_MASK,
+      mask);
+}
+
+bool TMC9660::Globals::setPullDirectionMask(uint32_t mask) noexcept {
+  return writeBank0(
+      tmc9660::tmcl::GlobalParamBank0::IO_INPUT_PULLUP_PULLDOWN_DIRECTION_MASK,
+      mask);
+}
+
+bool TMC9660::Globals::getPullDirectionMask(uint32_t &mask) noexcept {
+  return readBank0(
+      tmc9660::tmcl::GlobalParamBank0::IO_INPUT_PULLUP_PULLDOWN_DIRECTION_MASK,
+      mask);
+}
+
+bool TMC9660::Globals::setAutoStart(bool enable) noexcept {
+  return writeBank0(tmc9660::tmcl::GlobalParamBank0::AUTO_START_ENABLE,
+                    enable ? 1u : 0u);
+}
+
+bool TMC9660::Globals::getAutoStart(bool &enable) noexcept {
+  uint32_t tmp;
+  if (!readBank0(tmc9660::tmcl::GlobalParamBank0::AUTO_START_ENABLE, tmp))
+    return false;
+  enable = (tmp != 0);
+  return true;
+}
+
+bool TMC9660::Globals::setClearUserVariables(bool clear) noexcept {
+  return writeBank0(tmc9660::tmcl::GlobalParamBank0::CLEAR_USER_VARIABLES,
+                    clear ? 1u : 0u);
+}
+
+bool TMC9660::Globals::getClearUserVariables(bool &clear) noexcept {
+  uint32_t tmp;
+  if (!readBank0(tmc9660::tmcl::GlobalParamBank0::CLEAR_USER_VARIABLES, tmp))
+    return false;
+  clear = (tmp != 0);
+  return true;
+}
+
+bool TMC9660::Globals::setUserVariable(uint8_t index, int32_t value) noexcept {
+  if (index > 15)
+    return false;
+  auto param = static_cast<tmc9660::tmcl::GlobalParamBank2>(index);
+  return writeBank2(param, value);
+}
+
+bool TMC9660::Globals::getUserVariable(uint8_t index, int32_t &value) noexcept {
+  if (index > 15)
+    return false;
+  auto param = static_cast<tmc9660::tmcl::GlobalParamBank2>(index);
+  return readBank2(param, value);
+}
+
+bool TMC9660::Globals::setTimerPeriod(uint8_t timer, uint32_t period_ms) noexcept {
+  if (timer > 2)
+    return false;
+  auto param = static_cast<tmc9660::tmcl::GlobalParamBank3>(timer);
+  return writeBank3(param, period_ms);
+}
+
+bool TMC9660::Globals::getTimerPeriod(uint8_t timer, uint32_t &period_ms) noexcept {
+  if (timer > 2)
+    return false;
+  auto param = static_cast<tmc9660::tmcl::GlobalParamBank3>(timer);
+  return readBank3(param, period_ms);
+}
+
+bool TMC9660::Globals::setInputTrigger(
+    uint8_t index, tmc9660::tmcl::TriggerTransition transition) noexcept {
+  if (index > 18)
+    return false;
+  auto param = static_cast<tmc9660::tmcl::GlobalParamBank3>(
+      static_cast<uint16_t>(tmc9660::tmcl::GlobalParamBank3::INPUT_0_TRIGGER_TRANSITION) +
+      index);
+  return writeBank3(param, static_cast<uint32_t>(transition));
+}
+
+bool TMC9660::Globals::getInputTrigger(
+    uint8_t index, tmc9660::tmcl::TriggerTransition &transition) noexcept {
+  if (index > 18)
+    return false;
+  auto param = static_cast<tmc9660::tmcl::GlobalParamBank3>(
+      static_cast<uint16_t>(tmc9660::tmcl::GlobalParamBank3::INPUT_0_TRIGGER_TRANSITION) +
+      index);
+  uint32_t tmp;
+  if (!readBank3(param, tmp))
+    return false;
+  transition = static_cast<tmc9660::tmcl::TriggerTransition>(tmp);
+  return true;
+}
+
+//-------------------------------------------------------------------------
+// Heartbeat and Power helpers (wrapping Globals)
+//-------------------------------------------------------------------------
+
+bool TMC9660::Heartbeat::configure(HeartbeatMode mode,
+                                   uint32_t timeout_ms) noexcept {
+  using tmc9660::tmcl::HeartbeatMonitoringConfig;
+  HeartbeatMonitoringConfig cfg =
+      (mode == HeartbeatMode::WATCHDOG_ENABLE)
+          ? HeartbeatMonitoringConfig::TMCL_UART_AND_SPI_INTERFACE
+          : HeartbeatMonitoringConfig::DISABLED;
+  return driver.globals.configureHeartbeat(cfg, timeout_ms);
+}
+
+bool TMC9660::Power::enableWakePin(bool enable) noexcept {
+  return driver.globals.writeBank0(
+      tmc9660::tmcl::GlobalParamBank0::WAKE_PIN_CONTROL_ENABLE,
+      enable ? 1u : 0u);
+}
+
+bool TMC9660::Power::enterPowerDown(PowerDownPeriod period) noexcept {
+  return driver.globals.writeBank0(
+      tmc9660::tmcl::GlobalParamBank0::GO_TO_TIMEOUT_POWER_DOWN_STATE,
+      static_cast<uint32_t>(period));
+}
 // TMC9660.cpp - Implementation of TMC9660 motor controller interface


### PR DESCRIPTION
## Summary
- expand `Globals` with high-level configuration helpers
- implement wrappers for heartbeat and power control

## Testing
- `g++ -std=c++17 -Iinc src/TMC9660.cpp examples/BLDC_with_HALL.cpp -o /tmp/testprog` *(fails: numerous compile errors)*