### PR TITLE
Add subset of missing TMC9660 API implementations

### DIFF
--- a/examples/BLDC_velocity_control.cpp
+++ b/examples/BLDC_velocity_control.cpp
@@ -26,7 +26,7 @@ int main() {
     driver.setMaxCurrent(1500);
 
     // 3. Configure an encoder for velocity feedback (e.g., 1024 counts per revolution).
-    driver.configureEncoder(1024, false);
+    driver.configureABNEncoder(1024);
 
     // 4. For DC motor, use open-loop current mode to drive the H-bridge.
     driver.setCommutationMode(TMC9660::CommutationMode::FOC_OPENLOOP_CURRENT);

--- a/examples/BLDC_with_HALL.cpp
+++ b/examples/BLDC_with_HALL.cpp
@@ -24,7 +24,7 @@ int main() {
     }
 
     // 2. Configure Hall sensor feedback (assuming standard hall sequence, not inverted).
-    driver.configureHallSensors(0, false);
+    driver.configureHall();
 
     // 3. Set commutation mode to FOC with Hall feedback.
     driver.setCommutationMode(TMC9660::CommutationMode::FOC_HALL);


### PR DESCRIPTION
## Summary
- implement FeedbackSense helper functions
- implement Protection API methods
- implement ABN encoder setup using parameter IDs
- rename examples to use new API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683e4db90a108328a270bacfb976a5df