### PR TITLE
Add TMCL scripting helpers

### DIFF
--- a/inc/TMC9660.hpp
+++ b/inc/TMC9660.hpp
@@ -2350,6 +2350,56 @@ public:
      */
     bool stop() noexcept;
 
+    /** @brief Execute a single TMCL instruction of the loaded script.
+     *
+     * Uses the `ApplStep` opcode which advances the interpreter by one
+     * instruction. Useful for debugging scripts in real time.
+     */
+    bool step() noexcept;
+
+    /** @brief Reset the TMCL program counter.
+     *
+     * Sends the `ApplReset` command which stops execution and resets the
+     * script to the beginning.
+     */
+    bool reset() noexcept;
+
+    /** @brief Query the execution state of the running script.
+     * @param[out] status Raw status value returned by `GetStatusScript`.
+     * @return true if the status value was retrieved successfully.
+     */
+    bool getStatus(uint32_t &status) noexcept;
+
+    /** @brief Read a 32-bit instruction from script memory.
+     * @param address Instruction address to read.
+     * @param[out] value Returned 32-bit TMCL instruction word.
+     * @return true on success.
+     */
+    bool readMemory(uint16_t address, uint32_t &value) noexcept;
+
+    /** @brief Add a breakpoint at the given address.
+     * @param address Instruction address where execution should break.
+     * @return true if the breakpoint was set.
+     */
+    bool addBreakpoint(uint16_t address) noexcept;
+
+    /** @brief Remove a previously set breakpoint.
+     * @param address Address of the breakpoint to remove.
+     * @return true if removed successfully.
+     */
+    bool removeBreakpoint(uint16_t address) noexcept;
+
+    /** @brief Remove all breakpoints from the script.
+     * @return true if the command succeeded.
+     */
+    bool clearBreakpoints() noexcept;
+
+    /** @brief Query the maximum number of supported breakpoints.
+     * @param[out] count Maximum breakpoint count reported by the device.
+     * @return true on success.
+     */
+    bool getMaxBreakpointCount(uint32_t &count) noexcept;
+
   private:
     friend class TMC9660;
     explicit Script(TMC9660 &parent) noexcept : driver(parent) {}

--- a/src/TMC9660.cpp
+++ b/src/TMC9660.cpp
@@ -531,11 +531,43 @@ bool TMC9660::Script::upload(const std::vector<uint32_t> &scriptData) noexcept {
 
 bool TMC9660::Script::start(uint16_t address) noexcept {
   uint16_t type = (address == 0) ? 0 : 1;
-  return driver.sendCommand(tmc9660::tmcl::Op::APPL_RUN, type, 0, address, nullptr);
+  return driver.sendCommand(tmc9660::tmcl::Op::ApplRun, type, 0, address, nullptr);
 }
 
 bool TMC9660::Script::stop() noexcept {
-  return driver.sendCommand(tmc9660::tmcl::Op::APPL_STOP, 0, 0, 0, nullptr);
+  return driver.sendCommand(tmc9660::tmcl::Op::ApplStop, 0, 0, 0, nullptr);
+}
+
+bool TMC9660::Script::step() noexcept {
+  return driver.sendCommand(tmc9660::tmcl::Op::ApplStep, 0, 0, 0, nullptr);
+}
+
+bool TMC9660::Script::reset() noexcept {
+  return driver.sendCommand(tmc9660::tmcl::Op::ApplReset, 0, 0, 0, nullptr);
+}
+
+bool TMC9660::Script::getStatus(uint32_t &status) noexcept {
+  return driver.sendCommand(tmc9660::tmcl::Op::GetStatusScript, 0, 0, 0, &status);
+}
+
+bool TMC9660::Script::readMemory(uint16_t address, uint32_t &value) noexcept {
+  return driver.sendCommand(tmc9660::tmcl::Op::ReadMem, 0, 0, address, &value);
+}
+
+bool TMC9660::Script::addBreakpoint(uint16_t address) noexcept {
+  return driver.sendCommand(tmc9660::tmcl::Op::Breakpoint, 0, 0, address, nullptr);
+}
+
+bool TMC9660::Script::removeBreakpoint(uint16_t address) noexcept {
+  return driver.sendCommand(tmc9660::tmcl::Op::Breakpoint, 1, 0, address, nullptr);
+}
+
+bool TMC9660::Script::clearBreakpoints() noexcept {
+  return driver.sendCommand(tmc9660::tmcl::Op::Breakpoint, 2, 0, 0, nullptr);
+}
+
+bool TMC9660::Script::getMaxBreakpointCount(uint32_t &count) noexcept {
+  return driver.sendCommand(tmc9660::tmcl::Op::Breakpoint, 3, 0, 0, &count);
 }
 
 //-------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- extend `Script` subsystem with runtime TMCL control helpers
- implement ApplStep/ApplReset/GetStatusScript and breakpoint helpers

## Testing
- `g++ -std=c++20 -Iinc -c src/TMC9660.cpp` *(fails: invalid use of incomplete type and macro redefinitions)*

------
https://chatgpt.com/codex/tasks/task_e_683f81ad771483288a7d328f2082d98c