### PR TITLE
Improve TMCL frame handling

### DIFF
--- a/examples/BLDC_velocity_control.cpp
+++ b/examples/BLDC_velocity_control.cpp
@@ -3,11 +3,10 @@
 
 // Example: Configure a brushed DC motor for velocity control with an encoder feedback.
 
-class MySPIInterface : public TMC9660CommInterface {
+class MySPIInterface : public SPITMC9660CommInterface {
 public:
-    bool transferDatagram(const std::array<uint8_t,8>& tx, std::array<uint8_t,8>& rx) override {
-        // Simulate SPI transfer (in real code, perform hardware SPI exchange).
-        rx = tx;
+    bool spiTransfer(std::array<uint8_t,8>& tx, std::array<uint8_t,8>& rx) noexcept override {
+        rx = tx; // echo back for demo purposes
         return true;
     }
 };

--- a/examples/BLDC_with_HALL.cpp
+++ b/examples/BLDC_with_HALL.cpp
@@ -3,11 +3,10 @@
 
 // Example: Initialize and run a BLDC motor with Hall sensors using the TMC9660.
 
-class MySPIInterface : public TMC9660CommInterface {
+class MySPIInterface : public SPITMC9660CommInterface {
 public:
-    bool transferDatagram(const std::array<uint8_t,8>& tx, std::array<uint8_t,8>& rx) override {
-        // TODO: Implement actual SPI transfer. Here we simulate a perfect transfer (echo back for demo).
-        rx = tx;
+    bool spiTransfer(std::array<uint8_t,8>& tx, std::array<uint8_t,8>& rx) noexcept override {
+        rx = tx; // echo back for demo
         return true;
     }
 };

--- a/examples/Telemetry_monitor.cpp
+++ b/examples/Telemetry_monitor.cpp
@@ -5,13 +5,10 @@
 
 // Example: Using telemetry APIs to read temperature, current, and voltage continuously.
 
-class MySPIInterface : public TMC9660CommInterface {
+class MySPIInterface : public SPITMC9660CommInterface {
 public:
-    bool transferDatagram(const std::array<uint8_t,8>& tx, std::array<uint8_t,8>& rx) override {
-        // In real code, perform SPI transfer. Here, simulate device response.
-        rx = tx;
-        // If this were a read operation, rx[4-7] would contain actual values from the device.
-        // (For demonstration, we leave it echoing the sent data.)
+    bool spiTransfer(std::array<uint8_t,8>& tx, std::array<uint8_t,8>& rx) noexcept override {
+        rx = tx; // echo back
         return true;
     }
 };

--- a/inc/TMC9660.hpp
+++ b/inc/TMC9660.hpp
@@ -43,8 +43,6 @@ public:
     return {op, type, motor, value};
   }
 
-  // Compute TMCL checksum (sum of bytes 0-6)
-  [[nodiscard]] uint8_t computeChecksum(const uint8_t *datagram) noexcept;
 
   /** @brief Set (write) an axis (motor-specific) parameter on the TMC9660.
    * @param id Parameter ID number (see TMC9660 documentation for the full
@@ -92,12 +90,10 @@ public:
                                           uint8_t bank,
                                           uint32_t &value) noexcept;
 
-  /// Send a raw TMCL command and get reply
-  TMCLReply sendCommand(uint8_t opCode, uint16_t type = 0,
-                        uint8_t motorOrBank = 0, uint32_t value = 0);
-
-  bool sendCommand(tmc9660::tmcl::Op opcode, uint16_t type, uint8_t motor,
-                    uint32_t value, uint32_t *reply) noexcept;
+  /// Send a TMCL command. Optionally return the 32-bit reply value.
+  bool sendCommand(tmc9660::tmcl::Op opcode, uint16_t type = 0,
+                   uint8_t motor = 0, uint32_t value = 0,
+                   uint32_t *reply = nullptr) noexcept;
 
   //***************************************************************************
   //**                  SUBSYSTEM: Motor Configuration                     **//

--- a/src/TMC9660.cpp
+++ b/src/TMC9660.cpp
@@ -29,36 +29,9 @@ bool TMC9660::readGlobalParameter(GlobalParamBankVariant id, uint8_t bank, uint3
   return this->sendCommand(tmc9660::tmcl::Op::GGP, paramId, bank, 0, &value);
 }
 
-TMCLReply TMC9660::sendCommand(uint8_t op, uint16_t type,
-                                        uint8_t motor, uint32_t value) {
-  uint8_t tx[8] = {0};
-  uint8_t rx[8] = {0};
-  tx[0] = op;
-  tx[1] = static_cast<uint8_t>((type >> 4) & 0xFF);
-  tx[2] = static_cast<uint8_t>(((type & 0xF) << 4) | (motor & 0xF));
-  tx[3] = static_cast<uint8_t>((value >> 24) & 0xFF);
-  tx[4] = static_cast<uint8_t>((value >> 16) & 0xFF);
-  tx[5] = static_cast<uint8_t>((value >> 8) & 0xFF);
-  tx[6] = static_cast<uint8_t>(value & 0xFF);
-  tx[7] = computeChecksum(tx);
-
-  TMCLReply rep{};
-  if (!transferDatagram(tx, rx)) {
-    rep.status = 0xFF;
-    rep.value = 0;
-    return rep;
-  }
-
-  rep.status = rx[1];
-  rep.value = (static_cast<uint32_t>(rx[3]) << 24) |
-              (static_cast<uint32_t>(rx[4]) << 16) |
-              (static_cast<uint32_t>(rx[5]) << 8) |
-              static_cast<uint32_t>(rx[6]);
-  return rep;
-}
-
-bool TMC9660::sendCommand(tmc9660::tmcl::Op opcode, uint16_t type, uint8_t motor,
-                          uint32_t value, uint32_t *reply) noexcept {
+bool TMC9660::sendCommand(tmc9660::tmcl::Op opcode, uint16_t type,
+                          uint8_t motor, uint32_t value,
+                          uint32_t *reply) noexcept {
   TMCLFrame tx{};
   tx.opcode = static_cast<uint8_t>(opcode);
   tx.type   = type;
@@ -2999,13 +2972,5 @@ bool TMC9660::GPIO::readAnalog(uint8_t pin, uint16_t &value) noexcept {
   //==================================================
   // PRIVATE MEMBERS
   //==================================================
-
-uint8_t TMC9660::computeChecksum(const uint8_t *d) {
-  uint16_t sum = 0;
-  for (int i = 0; i < 7; ++i)
-    sum += d[i];
-  return static_cast<uint8_t>(sum & 0xFF);
-}
-
 
 // TMC9660.cpp - Implementation of TMC9660 motor controller interface


### PR DESCRIPTION
## Summary
- refine `TMC9660CommInterface` to handle SPI/UART modes
- add checksum helpers and proper frame packing
- simplify driver sendCommand API
- update examples for new SPI interface
- document new interface usage in README

## Testing
- `g++ -std=c++20 -Iinc /tmp/test.cpp -c -o /tmp/test.o` *(fails: multiple redefinition errors in tmcl headers)*

------
https://chatgpt.com/codex/tasks/task_e_684079291c3c83289b8d84105a4ec557