### PR TITLE
Enhance comm interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,12 @@ class TMC9660CommInterface {
 public:
     virtual ~TMC9660CommInterface() = default;
     virtual CommMode mode() const noexcept = 0;
-    virtual bool sendDatagram(const TMCLFrame& tx) noexcept = 0;
-    virtual bool receiveDatagram(TMCLFrame& rx) noexcept = 0;
-    virtual bool transferDatagram(const TMCLFrame& tx,
-                                  TMCLFrame& rx) noexcept = 0;
+
+    /// Send @p tx and decode reply according to the active mode.
+    /// @param address 7-bit module address (UART only).
+    virtual bool transfer(const TMCLFrame& tx,
+                          TMCLReply& reply,
+                          uint8_t address) noexcept = 0;
 };
 ```
 

--- a/src/TMC9660.cpp
+++ b/src/TMC9660.cpp
@@ -38,12 +38,13 @@ bool TMC9660::sendCommand(tmc9660::tmcl::Op opcode, uint16_t type,
   tx.motor  = motor;
   tx.value  = value;
 
-  TMCLFrame rx{};
-  if (!comm_.transferDatagram(tx, rx))
+  TMCLReply rep{};
+  if (!comm_.transfer(tx, rep, address_))
     return false;
-
+  if (!rep.isOK())
+    return false;
   if (reply)
-    *reply = rx.value;
+    *reply = rep.value;
   return true;
 }
 


### PR DESCRIPTION
## Summary
- update doc tables for UART and SPI in `TMC9660CommInterface.hpp`
- refactor TMCL reply handling for UART
- unify `TMC9660CommInterface` to single `transfer()` method
- adjust `TMC9660` to use new reply structure
- update README communication interface snippet

## Testing
- `g++ -std=c++20 -Iinc src/TMC9660.cpp examples/BLDC_with_HALL.cpp -o /tmp/out`


------
https://chatgpt.com/codex/tasks/task_e_68407cc98c1c832885e74af18a9437e4