### PR TITLE
Fix SPI encoder config enum usage

### DIFF
--- a/inc/TMC9660.hpp
+++ b/inc/TMC9660.hpp
@@ -996,8 +996,8 @@ public:
      * @param csIdleTimeUs CS idle time between frames in microseconds (0-102).
      * @return true if configured successfully.
      */
-    bool configureSPIEncoder(uint8_t cmdSize, uint16_t csSettleTimeNs = 0,
-                             uint8_t csIdleTimeUs = 0) noexcept;
+    bool configureSPIEncoder(uint8_t cmdSize, uint16_t csSettleTimeNs,
+                             uint8_t csIdleTimeUs) noexcept;
 
     /** @brief Configure SPI encoder data format and processing.
      *

--- a/src/TMC9660.cpp
+++ b/src/TMC9660.cpp
@@ -893,12 +893,19 @@ bool TMC9660::FeedbackSense::getSecondaryABNEncoderValue(
     //  SPI encoder timing & frame size
     // –––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
 
-bool TMC9660::FeedbackSense::configureSPIEncoder(uint8_t cmdSize, uint16_t csSettleTimeNs,
-                                  uint8_t csIdleTimeUs) noexcept {
+bool TMC9660::FeedbackSense::configureSPIEncoder(uint8_t cmdSize,
+                                                 uint16_t csSettleTimeNs,
+                                                 uint8_t csIdleTimeUs) noexcept {
   bool ok = true;
-  ok &= driver.writeParameter(180, cmdSize);
-  ok &= driver.writeParameter(181, csSettleTimeNs);
-  ok &= driver.writeParameter(182, csIdleTimeUs);
+  ok &= driver.writeParameter(
+      tmc9660::tmcl::Parameters::SPI_ENCODER_MAIN_TRANSFER_CMD_SIZE,
+      cmdSize);
+  ok &= driver.writeParameter(
+      tmc9660::tmcl::Parameters::SPI_ENCODER_CS_SETTLE_DELAY_TIME,
+      csSettleTimeNs);
+  ok &= driver.writeParameter(
+      tmc9660::tmcl::Parameters::SPI_ENCODER_CS_IDLE_DELAY_TIME,
+      csIdleTimeUs);
   return ok;
 }
   


### PR DESCRIPTION
## Summary
- fix SPI encoder configuration to use correct parameter enums
- update header to match datasheet signature

## Testing
- `g++ -std=c++17 -Wall -Wextra -c src/TMC9660.cpp -Iinc -o /tmp/t.o` *(fails: ‘std::span’ has not been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6840872e3f508328bef13bb96da31281