### PR TITLE
Add TMC9660 bootloader skeleton

### DIFF
--- a/inc/TMC9660.hpp
+++ b/inc/TMC9660.hpp
@@ -9,6 +9,7 @@
 
 #include "TMC9660CommInterface.hpp"
 #include "parameter_mode/tmc9660_param_mode_tmcl.hpp"
+#include "TMC9660Bootloader.hpp"
 
 /** @brief Main class representing a TMC9660 motor driver in Parameter Mode.
  * Provides high-level functions to configure and control the TMC9660's
@@ -31,7 +32,10 @@ public:
    * @param address (Optional) Module address if multiple TMC9660 devices are on
    * one bus. For SPI, this is typically 0.
    */
-  TMC9660(TMC9660CommInterface &comm, uint8_t address = 0) noexcept;
+  TMC9660(TMC9660CommInterface &comm, uint8_t address = 0,
+          const tmc9660::BootloaderConfig *bootCfg = nullptr) noexcept;
+
+  bool bootloaderInit(const tmc9660::BootloaderConfig &cfg) noexcept;
 
   //***************************************************************************
   //**               CORE PARAMETER ACCESS METHODS                         **//
@@ -2703,6 +2707,7 @@ private:
                                ///< sending/receiving data.
   uint8_t address_; ///< Module address (0-127). Used primarily for UART
                     ///< multi-drop addressing.
+  tmc9660::TMC9660Bootloader bootloader_; ///< Bootloader helper
 
 #ifdef TMC_API_EXTERNAL_CRC_TABLE
   extern const uint8_t tmcCRCTable_Poly7Reflected[256];

--- a/inc/TMC9660Bootloader.hpp
+++ b/inc/TMC9660Bootloader.hpp
@@ -1,0 +1,191 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+#include "TMC9660CommInterface.hpp"
+
+namespace tmc9660 {
+
+namespace bootcfg {
+
+constexpr uint8_t LDO_DISABLED = 0;
+constexpr uint8_t LDO_2V5     = 1;
+constexpr uint8_t LDO_3V3     = 2;
+constexpr uint8_t LDO_5V0     = 3;
+
+constexpr uint8_t LDO_SLOPE_3MS    = 0;
+constexpr uint8_t LDO_SLOPE_1_5MS  = 1;
+constexpr uint8_t LDO_SLOPE_0_75MS = 2;
+constexpr uint8_t LDO_SLOPE_0_37MS = 3;
+
+constexpr uint8_t BOOT_MODE_REGISTER  = 1;
+constexpr uint8_t BOOT_MODE_PARAMETER = 2;
+
+constexpr uint8_t UART_RX_GPIO7 = 0;
+constexpr uint8_t UART_RX_GPIO1 = 1;
+constexpr uint8_t UART_TX_GPIO6 = 0;
+constexpr uint8_t UART_TX_GPIO0 = 1;
+
+constexpr uint8_t UART_BAUD_9600   = 0;
+constexpr uint8_t UART_BAUD_19200  = 1;
+constexpr uint8_t UART_BAUD_38400  = 2;
+constexpr uint8_t UART_BAUD_57600  = 3;
+constexpr uint8_t UART_BAUD_115200 = 4;
+constexpr uint8_t UART_BAUD_1000000 = 5;
+constexpr uint8_t UART_BAUD_AUTO_8X  = 6;
+constexpr uint8_t UART_BAUD_AUTO_16X = 7;
+
+constexpr uint8_t RS485_TXEN_NONE = 0;
+constexpr uint8_t RS485_TXEN_GPIO8 = 1;
+constexpr uint8_t RS485_TXEN_GPIO2 = 2;
+
+constexpr uint8_t SPI_IFACE0 = 0;
+constexpr uint8_t SPI_IFACE1 = 1;
+
+constexpr uint8_t SPI0_SCK_GPIO6  = 0;
+constexpr uint8_t SPI0_SCK_GPIO11 = 1;
+
+constexpr uint8_t SPI_FLASH_FREQ_DIV1  = 0;
+constexpr uint8_t SPI_FLASH_FREQ_DIV2  = 1;
+constexpr uint8_t SPI_FLASH_FREQ_DIV4  = 3;
+
+constexpr uint8_t I2C_SDA_GPIO5  = 0;
+constexpr uint8_t I2C_SDA_GPIO11 = 1;
+constexpr uint8_t I2C_SDA_GPIO14 = 2;
+
+constexpr uint8_t I2C_SCL_GPIO4  = 0;
+constexpr uint8_t I2C_SCL_GPIO12 = 1;
+constexpr uint8_t I2C_SCL_GPIO13 = 2;
+
+constexpr uint8_t I2C_FREQ_100KHZ = 0;
+constexpr uint8_t I2C_FREQ_200KHZ = 1;
+constexpr uint8_t I2C_FREQ_400KHZ = 2;
+constexpr uint8_t I2C_FREQ_800KHZ = 3;
+
+constexpr uint8_t CLK_USE_INTERNAL = 0;
+constexpr uint8_t CLK_USE_EXTERNAL = 1;
+
+constexpr uint8_t EXT_SOURCE_OSCILLATOR = 0;
+constexpr uint8_t EXT_SOURCE_CLOCK     = 1;
+
+constexpr uint8_t XTAL_FREQ_8MHZ   = 1;
+constexpr uint8_t XTAL_FREQ_16MHZ  = 3;
+constexpr uint8_t XTAL_FREQ_24MHZ  = 5;
+constexpr uint8_t XTAL_FREQ_32MHZ  = 6;
+
+constexpr uint8_t SYSCLK_USE_INTOSC = 0;
+constexpr uint8_t SYSCLK_USE_PLL    = 1;
+
+constexpr uint8_t SYSCLK_DIV_1   = 0;
+constexpr uint8_t SYSCLK_DIV_2_3 = 3;
+
+} // namespace bootcfg
+
+struct LDOConfig {
+  uint8_t vext1{bootcfg::LDO_DISABLED};
+  uint8_t vext2{bootcfg::LDO_DISABLED};
+  uint8_t slope_vext1{bootcfg::LDO_SLOPE_3MS};
+  uint8_t slope_vext2{bootcfg::LDO_SLOPE_3MS};
+  bool    ldo_short_fault{false};
+};
+
+struct BootConfig {
+  uint8_t boot_mode{bootcfg::BOOT_MODE_REGISTER};
+  bool    bl_ready_fault{false};
+  bool    bl_exit_fault{true};
+  bool    disable_selftest{false};
+  bool    bl_config_fault{false};
+  bool    start_motor_control{false};
+};
+
+struct UARTConfig {
+  uint8_t device_address{1};
+  uint8_t host_address{255};
+  bool    disable_uart{false};
+  uint8_t rx_pin{bootcfg::UART_RX_GPIO7};
+  uint8_t tx_pin{bootcfg::UART_TX_GPIO6};
+  uint8_t baud_rate{bootcfg::UART_BAUD_115200};
+};
+
+struct RS485Config {
+  bool    enable_rs485{false};
+  uint8_t txen_pin{bootcfg::RS485_TXEN_NONE};
+  uint8_t txen_pre_delay{0};
+  uint8_t txen_post_delay{0};
+};
+
+struct SPIBootConfig {
+  bool    disable_spi{false};
+  uint8_t boot_spi_iface{bootcfg::SPI_IFACE0};
+  uint8_t spi0_sck_pin{bootcfg::SPI0_SCK_GPIO6};
+};
+
+struct SPIFlashConfig {
+  bool    enable_flash{false};
+  uint8_t flash_spi_iface{bootcfg::SPI_IFACE1};
+  uint8_t spi0_sck_pin{bootcfg::SPI0_SCK_GPIO6};
+  uint8_t cs_pin{0};
+  uint8_t freq_div{bootcfg::SPI_FLASH_FREQ_DIV4};
+};
+
+struct I2CConfig {
+  bool    enable_eeprom{false};
+  uint8_t sda_pin{bootcfg::I2C_SDA_GPIO5};
+  uint8_t scl_pin{bootcfg::I2C_SCL_GPIO4};
+  uint8_t address_bits{0};
+  uint8_t freq_code{bootcfg::I2C_FREQ_100KHZ};
+};
+
+struct ClockConfig {
+  uint8_t use_external{bootcfg::CLK_USE_INTERNAL};
+  uint8_t ext_source_type{bootcfg::EXT_SOURCE_OSCILLATOR};
+  uint8_t xtal_drive{bootcfg::XTAL_FREQ_16MHZ};
+  bool    xtal_boost{false};
+  uint8_t pll_selection{bootcfg::SYSCLK_USE_PLL};
+  uint8_t rdiv{14};
+  uint8_t sysclk_div{bootcfg::SYSCLK_DIV_1};
+};
+
+struct GPIOConfig {
+  uint32_t outputMask{0};
+  uint32_t directionMask{0};
+  uint32_t pullUpMask{0};
+  uint32_t pullDownMask{0};
+  uint32_t analogMask{0};
+};
+
+struct BootloaderConfig {
+  LDOConfig     ldo;
+  BootConfig    boot;
+  UARTConfig    uart;
+  RS485Config   rs485;
+  SPIBootConfig spiComm;
+  SPIFlashConfig spiFlash;
+  I2CConfig     i2c;
+  ClockConfig   clock;
+  GPIOConfig    gpio;
+};
+
+class TMC9660Bootloader {
+public:
+  explicit TMC9660Bootloader(TMC9660CommInterface &comm, uint8_t address = 0) noexcept;
+
+  bool setBank(uint8_t bank) noexcept;
+  bool setAddress(uint32_t addr) noexcept;
+  bool write8(uint8_t v) noexcept;
+  bool write16(uint16_t v) noexcept;
+  bool write32(uint32_t v) noexcept;
+  bool write32Inc(const uint32_t *values, size_t count) noexcept;
+  bool otpBurn(uint8_t page) noexcept;
+
+  bool applyConfiguration(const BootloaderConfig &cfg) noexcept;
+
+private:
+  bool sendCommand(uint8_t op, uint16_t type, uint8_t bank, uint32_t value, uint32_t *reply = nullptr) noexcept;
+
+  TMC9660CommInterface &comm_;
+  uint8_t address_;
+};
+
+} // namespace tmc9660
+

--- a/src/TMC9660.cpp
+++ b/src/TMC9660.cpp
@@ -3,9 +3,16 @@
 #include <chrono>
 #include <thread>
 
-TMC9660::TMC9660(TMC9660CommInterface &comm, uint8_t address)
-    : comm_(comm), address_(address & 0x7F) // ensure address is 7-bit
-{ }
+TMC9660::TMC9660(TMC9660CommInterface &comm, uint8_t address, const tmc9660::BootloaderConfig *bootCfg)
+    : comm_(comm), address_(address & 0x7F), bootloader_(comm, address) /* ensure address is 7-bit */
+{
+  if (bootCfg)
+    bootloaderInit(*bootCfg);
+}
+bool TMC9660::bootloaderInit(const tmc9660::BootloaderConfig &cfg) noexcept {
+  return bootloader_.applyConfiguration(cfg);
+}
+
 
 //***************************************************************************
 //**               CORE PARAMETER ACCESS METHODS                         **//

--- a/src/TMC9660Bootloader.cpp
+++ b/src/TMC9660Bootloader.cpp
@@ -1,0 +1,66 @@
+#include "TMC9660Bootloader.hpp"
+#include <array>
+
+using namespace tmc9660;
+
+TMC9660Bootloader::TMC9660Bootloader(TMC9660CommInterface &comm, uint8_t address) noexcept
+  : comm_(comm), address_(address & 0x7F) {}
+
+bool TMC9660Bootloader::sendCommand(uint8_t op, uint16_t type, uint8_t bank, uint32_t value, uint32_t *reply) noexcept {
+  TMCLFrame tx{};
+  tx.opcode = op;
+  tx.type   = type;
+  tx.motor  = bank;
+  tx.value  = value;
+
+  TMCLReply rep{};
+  if (!comm_.transfer(tx, rep, address_))
+    return false;
+  if (!rep.isOK())
+    return false;
+  if (reply)
+    *reply = rep.value;
+  return true;
+}
+
+bool TMC9660Bootloader::setBank(uint8_t bank) noexcept {
+  return sendCommand(0x01, 0, bank, 0);
+}
+
+bool TMC9660Bootloader::setAddress(uint32_t addr) noexcept {
+  return sendCommand(0x02, static_cast<uint16_t>(addr >> 16), static_cast<uint8_t>(addr >> 8), addr & 0xFF);
+}
+
+bool TMC9660Bootloader::write8(uint8_t v) noexcept {
+  return sendCommand(0x03, 0, 0, v);
+}
+
+bool TMC9660Bootloader::write16(uint16_t v) noexcept {
+  return sendCommand(0x04, 0, 0, v);
+}
+
+bool TMC9660Bootloader::write32(uint32_t v) noexcept {
+  return sendCommand(0x05, 0, 0, v);
+}
+
+bool TMC9660Bootloader::write32Inc(const uint32_t *vals, size_t count) noexcept {
+  for (size_t i = 0; i < count; ++i) {
+    if (!write32(vals[i]))
+      return false;
+  }
+  return true;
+}
+
+bool TMC9660Bootloader::otpBurn(uint8_t page) noexcept {
+  return sendCommand(0x06, 0, page, 0);
+}
+
+bool TMC9660Bootloader::applyConfiguration(const BootloaderConfig &cfg) noexcept {
+  // Very simplified implementation: write only UART device/host address
+  if (!setBank(5)) return false; // CONFIG bank
+  if (!setAddress(0x00020002)) return false; // offset 2 for UART addresses
+  uint16_t word = static_cast<uint16_t>(cfg.uart.device_address) | (static_cast<uint16_t>(cfg.uart.host_address) << 8);
+  if (!write16(word)) return false;
+  return true;
+}
+


### PR DESCRIPTION
## Summary
- introduce `TMC9660Bootloader` helper class
- add bootloader configuration structs and enums
- integrate bootloader helper into `TMC9660`

## Testing
- `g++ -std=c++20 -Iinc -c src/TMC9660Bootloader.cpp -o /tmp/bl.o`

------
https://chatgpt.com/codex/tasks/task_e_6840896646148328bd65e0076a7a2c87