### PR TITLE
Make bootloader initialization configurable

### DIFF
--- a/inc/TMC9660.hpp
+++ b/inc/TMC9660.hpp
@@ -26,16 +26,20 @@
 class TMC9660 {
 public:
 
+  enum class BootloaderInitResult { Success, NoConfig, Failure };
+
   /** @brief Construct a TMC9660 driver instance.
    * @param comm Reference to a user-implemented communication interface (SPI,
    * UART, etc).
    * @param address (Optional) Module address if multiple TMC9660 devices are on
    * one bus. For SPI, this is typically 0.
    */
+
   TMC9660(TMC9660CommInterface &comm, uint8_t address = 0,
           const tmc9660::BootloaderConfig *bootCfg = nullptr) noexcept;
 
-  bool bootloaderInit(const tmc9660::BootloaderConfig &cfg) noexcept;
+  BootloaderInitResult bootloaderInit(
+      const tmc9660::BootloaderConfig *cfg = nullptr) noexcept;
 
   //***************************************************************************
   //**               CORE PARAMETER ACCESS METHODS                         **//
@@ -2701,6 +2705,7 @@ private:
   uint8_t address_; ///< Module address (0-127). Used primarily for UART
                     ///< multi-drop addressing.
   tmc9660::TMC9660Bootloader bootloader_; ///< Bootloader helper
+  const tmc9660::BootloaderConfig *bootCfg_;
 
 #ifdef TMC_API_EXTERNAL_CRC_TABLE
   extern const uint8_t tmcCRCTable_Poly7Reflected[256];

--- a/src/TMC9660.cpp
+++ b/src/TMC9660.cpp
@@ -3,14 +3,19 @@
 #include <chrono>
 #include <thread>
 
-TMC9660::TMC9660(TMC9660CommInterface &comm, uint8_t address, const tmc9660::BootloaderConfig *bootCfg)
-    : comm_(comm), address_(address & 0x7F), bootloader_(comm, address) /* ensure address is 7-bit */
-{
-  if (bootCfg)
-    bootloaderInit(*bootCfg);
-}
-bool TMC9660::bootloaderInit(const tmc9660::BootloaderConfig &cfg) noexcept {
-  return bootloader_.applyConfiguration(cfg);
+TMC9660::TMC9660(TMC9660CommInterface &comm, uint8_t address,
+                 const tmc9660::BootloaderConfig *bootCfg) noexcept
+    : comm_(comm), address_(address & 0x7F), bootloader_(comm, address),
+      bootCfg_(bootCfg) /* ensure address is 7-bit */ {}
+
+TMC9660::BootloaderInitResult
+TMC9660::bootloaderInit(const tmc9660::BootloaderConfig *cfg) noexcept {
+  const tmc9660::BootloaderConfig *useCfg = cfg ? cfg : bootCfg_;
+  if (!useCfg)
+    return BootloaderInitResult::NoConfig;
+  if (bootloader_.applyConfiguration(*useCfg))
+    return BootloaderInitResult::Success;
+  return BootloaderInitResult::Failure;
 }
 
 


### PR DESCRIPTION
## Summary
- allow delayed bootloader initialization
- add `BootloaderInitResult` enum
- return initialization status from `bootloaderInit`

## Testing
- `g++ -std=c++20 -Iinc src/TMC9660.cpp src/TMC9660Bootloader.cpp -c` *(fails: redeclaration of `LATCH_POSITION`)*

------
https://chatgpt.com/codex/tasks/task_e_68408db846cc8328bb99219446a23dd8