### PR TITLE
Improve example documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,21 @@ g++ -std=c++20 -Iinc src/TMC9660.cpp examples/BLDC_with_HALL.cpp -o hall_demo
 ```
 
 ## 💻 Usage Examples
-The `examples` folder contains small programs showing typical workflows.
-- **BLDC_with_HALL.cpp** – run a BLDC motor using Hall sensor feedback and FOC.
-- **BLDC_velocity_control.cpp** – drive a brushed DC motor using a simple velocity loop.
+The `examples` folder contains programs demonstrating the most common tasks.
+
+- **bootloader_example.cpp** – write bootloader configuration registers.
+- **BLDC_with_HALL.cpp** – run a BLDC motor using Hall sensor feedback.
+- **BLDC_with_ABN.cpp** – closed-loop FOC using an incremental encoder.
+- **BLDC_velocity_control.cpp** – drive a brushed DC motor with a simple velocity loop.
+- **DC_current_control.cpp** – open-loop current drive for a DC motor.
+- **Stepper_FOC.cpp** – position control of a stepper using FOC and an encoder.
+- **Stepper_step_dir.cpp** – enable the STEP/DIR interface with extrapolation.
 - **Telemetry_monitor.cpp** – continuously read temperature, current and voltage values.
 
-Compile these along with `src/TMC9660.cpp` and your interface implementation to try them out.
+Compile these along with `src/TMC9660.cpp` and your own implementation of
+`TMC9660CommInterface` (the examples use a simple `DummyBus` stub).  A more
+in-depth walkthrough of each scenario is provided in
+`docs/HardwareAgnosticExamples.md`.
 
 ## 🙌 Contributing
 Pull requests and feature ideas are welcome! Please format code with `clang-format` and sign off your commits.

--- a/docs/HardwareAgnosticExamples.md
+++ b/docs/HardwareAgnosticExamples.md
@@ -1,0 +1,196 @@
+# Extensive TMC9660 Examples
+
+This document collects hardware agnostic walkthroughs showing how to configure
+the TMC9660 from bootloader setup to running a variety of motors.  All code
+examples use a very small "DummyBus" that merely echoes SPI transfers.  When
+porting the library to real hardware you must implement your own class derived
+from `TMC9660CommInterface` and replace the dummy bus with that implementation.
+
+---
+
+## Bootloader Configuration
+
+The bootloader registers are configured via `TMC9660Bootloader`. The snippet
+below writes a minimal configuration enabling SPI and UART communication.  The
+`DummyBus` seen in all snippets simply echoes data and serves as a placeholder
+for your real SPI or UART implementation.
+
+```cpp
+#include "TMC9660.hpp"
+#include <iostream>
+
+class DummyBus : public SPITMC9660CommInterface {
+public:
+    bool spiTransfer(std::array<uint8_t,8>& tx,
+                     std::array<uint8_t,8>& rx) noexcept override {
+        rx = tx; // echo back for demonstration
+        return true;
+    }
+};
+
+int main() {
+    DummyBus bus;
+    TMC9660 driver(bus);
+
+    tmc9660::BootloaderConfig cfg{};
+    cfg.uart.baud_rate = tmc9660::bootcfg::BaudRate::BR115200;
+    cfg.spiComm.boot_spi_iface = tmc9660::bootcfg::SPIInterface::IFACE0;
+    cfg.clock.use_external = tmc9660::bootcfg::ClockSource::Internal;
+
+    auto result = driver.bootloaderInit(&cfg);
+    if (result == TMC9660::BootloaderInitResult::Success)
+        std::cout << "Bootloader configured" << std::endl;
+    else
+        std::cout << "Bootloader configuration failed" << std::endl;
+}
+```
+
+Compile with:
+
+```bash
+g++ -std=c++20 -Iinc src/TMC9660.cpp src/TMC9660Bootloader.cpp \
+    docs/bootloader_example.cpp -o bootloader_demo
+```
+
+---
+
+## BLDC with ABN Encoder
+
+This example configures a BLDC motor using an incremental ABN encoder for closed
+loop FOC control.  Again the `DummyBus` merely mimics the real transport layer.
+
+```cpp
+#include "TMC9660.hpp"
+#include <iostream>
+
+class DummyBus : public SPITMC9660CommInterface {
+public:
+    bool spiTransfer(std::array<uint8_t,8>& tx,
+                     std::array<uint8_t,8>& rx) noexcept override {
+        rx = tx;
+        return true;
+    }
+};
+
+int main() {
+    DummyBus bus;
+    TMC9660 driver(bus);
+
+    driver.motor.setType(tmc9660::tmcl::MotorType::BLDC_MOTOR, 7);
+    driver.motor.configureABNEncoder(2048);
+    driver.motor.setCommutationMode(
+        tmc9660::tmcl::CommutationMode::FOC_ENCODER);
+    driver.motor.setMaxTorqueCurrent(2000);
+    driver.rampGenerator.setTargetVelocity(1500);
+
+    std::cout << "Motor running with ABN feedback" << std::endl;
+}
+```
+
+---
+
+## Stepper Closed‑Loop Control
+
+The library can control a stepper motor using field‑oriented control. The
+following snippet sets up a stepper with an ABN encoder and commands a position
+move.  As before, `DummyBus` is just a stand‑in for a real bus driver.
+
+```cpp
+#include "TMC9660.hpp"
+#include <iostream>
+
+class DummyBus : public SPITMC9660CommInterface {
+public:
+    bool spiTransfer(std::array<uint8_t,8>& tx,
+                     std::array<uint8_t,8>& rx) noexcept override {
+        rx = tx;
+        return true;
+    }
+};
+
+int main() {
+    DummyBus bus;
+    TMC9660 driver(bus);
+
+    driver.motor.setType(tmc9660::tmcl::MotorType::STEPPER_MOTOR);
+    driver.motor.configureABNEncoder(4000);
+    driver.motor.setCommutationMode(
+        tmc9660::tmcl::CommutationMode::FOC_ENCODER);
+    driver.position.moveTo(1000);
+    std::cout << "Stepper moving to position 1000" << std::endl;
+}
+```
+
+---
+
+## Step/Dir Interface
+
+External controllers can drive the STEP/DIR pins while the TMC9660 extrapolates
+between pulses. Here a stepper motor is configured for 1/8 micro‑steps and the
+interface is enabled.  `DummyBus` once again represents the application‑specific
+communication layer.
+
+```cpp
+#include "TMC9660.hpp"
+#include <iostream>
+
+class DummyBus : public SPITMC9660CommInterface {
+public:
+    bool spiTransfer(std::array<uint8_t,8>& tx,
+                     std::array<uint8_t,8>& rx) noexcept override {
+        rx = tx;
+        return true;
+    }
+};
+
+int main() {
+    DummyBus bus;
+    TMC9660 driver(bus);
+
+    driver.motor.setType(tmc9660::tmcl::MotorType::STEPPER_MOTOR);
+    driver.stepDir.setMicrostepResolution(
+        tmc9660::tmcl::StepDirStepDividerShift::DIV8);
+    driver.stepDir.enableInterface(true);
+    driver.stepDir.enableExtrapolation(true);
+
+    std::cout << "STEP/DIR interface enabled" << std::endl;
+}
+```
+
+---
+
+## DC Motor Current Control
+
+A brushed DC motor can be driven using open‑loop current mode. The following
+example sets a current limit and commands a constant current.  Replace
+`DummyBus` with your hardware specific implementation when integrating.
+
+```cpp
+#include "TMC9660.hpp"
+#include <iostream>
+
+class DummyBus : public SPITMC9660CommInterface {
+public:
+    bool spiTransfer(std::array<uint8_t,8>& tx,
+                     std::array<uint8_t,8>& rx) noexcept override {
+        rx = tx;
+        return true;
+    }
+};
+
+int main() {
+    DummyBus bus;
+    TMC9660 driver(bus);
+
+    driver.motor.setType(tmc9660::tmcl::MotorType::DC_MOTOR);
+    driver.motor.setCommutationMode(
+        tmc9660::tmcl::CommutationMode::FOC_OPENLOOP_CURRENT);
+    driver.motor.setMaxTorqueCurrent(1000);
+    driver.rampGenerator.setTargetCurrent(500);
+
+    std::cout << "DC motor running in current mode" << std::endl;
+}
+```
+
+These snippets are minimal but cover the main features of the library. Refer to `inc/TMC9660.hpp` for all available parameters and helper methods.
+

--- a/examples/BLDC_velocity_control.cpp
+++ b/examples/BLDC_velocity_control.cpp
@@ -1,9 +1,16 @@
+/**
+ * @file BLDC_velocity_control.cpp
+ * @brief Brushed DC motor velocity control example.
+ *
+ * This sample illustrates how the driver API might be used from a host program.
+ * Replace the DummyBus class with your actual communication transport.
+ */
+
 #include <iostream>
 #include "TMC9660.hpp"
 
-// Example: Configure a brushed DC motor for velocity control with an encoder feedback.
-
-class MySPIInterface : public SPITMC9660CommInterface {
+/// Stub communication bus for documentation purposes
+class DummyBus : public SPITMC9660CommInterface {
 public:
     bool spiTransfer(std::array<uint8_t,8>& tx, std::array<uint8_t,8>& rx) noexcept override {
         rx = tx; // echo back for demo purposes
@@ -12,8 +19,8 @@ public:
 };
 
 int main() {
-    MySPIInterface spiBus;
-    TMC9660 driver(spiBus);
+    DummyBus bus;        //!< Replace with your communication driver
+    TMC9660 driver(bus);
 
     // 1. Configure motor type as DC.
     if (!driver.configureMotorType(TMC9660::MotorType::DC)) {

--- a/examples/BLDC_with_ABN.cpp
+++ b/examples/BLDC_with_ABN.cpp
@@ -1,0 +1,37 @@
+/**
+ * @file BLDC_with_ABN.cpp
+ * @brief Example showing closed-loop FOC on a BLDC motor using an ABN encoder.
+ *
+ * As with all examples, the "DummyBus" simply echoes SPI transfers so the code
+ * can be compiled on any machine.  Implement a real bus by deriving from
+ * ::TMC9660CommInterface when running on hardware.
+ */
+
+#include <iostream>
+#include "TMC9660.hpp"
+
+/// Stub communication bus used for demonstration only
+class DummyBus : public SPITMC9660CommInterface {
+public:
+    bool spiTransfer(std::array<uint8_t,8>& tx,
+                     std::array<uint8_t,8>& rx) noexcept override {
+        rx = tx;
+        return true;
+    }
+};
+
+int main() {
+    DummyBus bus;           //!< Replace with your hardware bus
+    TMC9660 driver(bus);    //!< Driver instance using that bus
+
+    // Configure motor parameters
+    driver.motor.setType(tmc9660::tmcl::MotorType::BLDC_MOTOR, 7);
+    driver.motor.configureABNEncoder(2048); // 2048 line incremental encoder
+    driver.motor.setCommutationMode(
+        tmc9660::tmcl::CommutationMode::FOC_ENCODER); // use encoder based FOC
+    driver.motor.setMaxTorqueCurrent(2000); // limit phase current to 2 A
+
+    // Start rotating
+    driver.rampGenerator.setTargetVelocity(1000);
+    std::cout << "BLDC motor running with ABN encoder" << std::endl;
+}

--- a/examples/BLDC_with_HALL.cpp
+++ b/examples/BLDC_with_HALL.cpp
@@ -1,9 +1,16 @@
+/**
+ * @file BLDC_with_HALL.cpp
+ * @brief Run a BLDC motor using Hall sensor feedback.
+ *
+ * The DummyBus defined below is a simple echo implementation so this example can
+ * be compiled without hardware.  Replace it with your own communication layer
+ * derived from ::TMC9660CommInterface.
+ */
+
 #include <iostream>
 #include "TMC9660.hpp"
 
-// Example: Initialize and run a BLDC motor with Hall sensors using the TMC9660.
-
-class MySPIInterface : public SPITMC9660CommInterface {
+class DummyBus : public SPITMC9660CommInterface {
 public:
     bool spiTransfer(std::array<uint8_t,8>& tx, std::array<uint8_t,8>& rx) noexcept override {
         rx = tx; // echo back for demo
@@ -12,8 +19,8 @@ public:
 };
 
 int main() {
-    MySPIInterface spiBus;
-    TMC9660 driver(spiBus);
+    DummyBus bus;       //!< Replace with your comms driver
+    TMC9660 driver(bus);
 
     // 1. Configure motor type as BLDC (3-phase) with specified pole pairs.
     uint8_t polePairs = 7;  // example pole pair count

--- a/examples/DC_current_control.cpp
+++ b/examples/DC_current_control.cpp
@@ -1,0 +1,34 @@
+/**
+ * @file DC_current_control.cpp
+ * @brief Demonstrates open-loop current mode for a brushed DC motor.
+ *
+ * The bus implementation is left to the user; here we provide a minimal stub so
+ * the example can compile without hardware.
+ */
+
+#include <iostream>
+#include "TMC9660.hpp"
+
+/// Dummy communication bus echoing transfers back
+class DummyBus : public SPITMC9660CommInterface {
+public:
+    bool spiTransfer(std::array<uint8_t,8>& tx,
+                     std::array<uint8_t,8>& rx) noexcept override {
+        rx = tx;
+        return true;
+    }
+};
+
+int main() {
+    DummyBus bus;        //!< Replace with actual transport
+    TMC9660 driver(bus); //!< Driver communicating with the TMC9660
+
+    // Configure motor and drive settings
+    driver.motor.setType(tmc9660::tmcl::MotorType::DC_MOTOR);
+    driver.motor.setCommutationMode(
+        tmc9660::tmcl::CommutationMode::FOC_OPENLOOP_CURRENT);
+    driver.motor.setMaxTorqueCurrent(1000);  // peak current in mA
+    driver.rampGenerator.setTargetCurrent(500); // hold 500 mA
+
+    std::cout << "DC motor current control active" << std::endl;
+}

--- a/examples/Stepper_FOC.cpp
+++ b/examples/Stepper_FOC.cpp
@@ -1,0 +1,33 @@
+/**
+ * @file Stepper_FOC.cpp
+ * @brief Closed-loop FOC position control of a stepper motor.
+ *
+ * The communication bus must be provided by the integrator.  Here a small dummy
+ * implementation is used purely for documentation and unit tests.
+ */
+
+#include <iostream>
+#include "TMC9660.hpp"
+
+/// Example bus that echoes traffic back
+class DummyBus : public SPITMC9660CommInterface {
+public:
+    bool spiTransfer(std::array<uint8_t,8>& tx,
+                     std::array<uint8_t,8>& rx) noexcept override {
+        rx = tx;
+        return true;
+    }
+};
+
+int main() {
+    DummyBus bus;        //!< Replace with real bus
+    TMC9660 driver(bus); //!< Motor driver instance
+
+    driver.motor.setType(tmc9660::tmcl::MotorType::STEPPER_MOTOR);
+    driver.motor.configureABNEncoder(4000);      // encoder resolution
+    driver.motor.setCommutationMode(
+        tmc9660::tmcl::CommutationMode::FOC_ENCODER);
+
+    driver.position.moveTo(500);                 // command position
+    std::cout << "Stepper moving to position 500" << std::endl;
+}

--- a/examples/Stepper_step_dir.cpp
+++ b/examples/Stepper_step_dir.cpp
@@ -1,0 +1,33 @@
+/**
+ * @file Stepper_step_dir.cpp
+ * @brief Using the STEP/DIR interface with extrapolation.
+ *
+ * A dummy communication bus is provided for illustrative purposes only.  You
+ * should replace this with your own SPI/UART implementation.
+ */
+
+#include <iostream>
+#include "TMC9660.hpp"
+
+/// Stub bus used by the example
+class DummyBus : public SPITMC9660CommInterface {
+public:
+    bool spiTransfer(std::array<uint8_t,8>& tx,
+                     std::array<uint8_t,8>& rx) noexcept override {
+        rx = tx;
+        return true;
+    }
+};
+
+int main() {
+    DummyBus bus;        //!< Replace with actual transport
+    TMC9660 driver(bus); //!< Driver instance
+
+    driver.motor.setType(tmc9660::tmcl::MotorType::STEPPER_MOTOR);
+    driver.stepDir.setMicrostepResolution(
+        tmc9660::tmcl::StepDirStepDividerShift::DIV8);
+    driver.stepDir.enableInterface(true);  // enable STEP/DIR pins
+    driver.stepDir.enableExtrapolation(true); // smooth interpolation
+
+    std::cout << "STEP/DIR interface active" << std::endl;
+}

--- a/examples/Telemetry_monitor.cpp
+++ b/examples/Telemetry_monitor.cpp
@@ -1,11 +1,17 @@
+/**
+ * @file Telemetry_monitor.cpp
+ * @brief Polling telemetry data from the TMC9660.
+ *
+ * The library does not ship with a specific bus implementation.  The DummyBus
+ * below merely echoes transfers so the example can run anywhere.
+ */
+
 #include <iostream>
 #include <thread>
 #include <chrono>
 #include "TMC9660.hpp"
 
-// Example: Using telemetry APIs to read temperature, current, and voltage continuously.
-
-class MySPIInterface : public SPITMC9660CommInterface {
+class DummyBus : public SPITMC9660CommInterface {
 public:
     bool spiTransfer(std::array<uint8_t,8>& tx, std::array<uint8_t,8>& rx) noexcept override {
         rx = tx; // echo back
@@ -14,8 +20,8 @@ public:
 };
 
 int main() {
-    MySPIInterface spiBus;
-    TMC9660 driver(spiBus);
+    DummyBus bus;       //!< Replace with your communication layer
+    TMC9660 driver(bus);
 
     // Assume motor is configured and running. We will poll telemetry.
     for (int i = 0; i < 5; ++i) {

--- a/examples/bootloader_example.cpp
+++ b/examples/bootloader_example.cpp
@@ -1,0 +1,46 @@
+/**
+ * @file bootloader_example.cpp
+ * @brief Demonstrates how to configure the bootloader registers.
+ *
+ * The library itself does not implement any communication back‑end.  Users must
+ * provide their own class deriving from ::TMC9660CommInterface.  This example
+ * uses a minimal "DummyBus" that simply echoes all transfers so the program can
+ * be compiled and run on a desktop machine without hardware.
+ */
+
+#include <iostream>
+#include "TMC9660.hpp"
+
+/**
+ * @brief Minimal SPI bus stub used for demonstration.
+ *
+ * Replace this with your real SPI or UART implementation when running on the
+ * target hardware.
+ */
+class DummyBus : public SPITMC9660CommInterface {
+public:
+    bool spiTransfer(std::array<uint8_t,8>& tx,
+                     std::array<uint8_t,8>& rx) noexcept override {
+        rx = tx; //!< Echo data back to emulate a device
+        return true;
+    }
+};
+
+int main() {
+    DummyBus bus;               //!< Replace with your real bus
+    TMC9660 driver(bus);        //!< Driver communicating over that bus
+
+    // Build a bootloader configuration structure.
+    tmc9660::BootloaderConfig cfg{};
+    cfg.uart.baud_rate = tmc9660::bootcfg::BaudRate::BR115200; ///< Example UART speed
+    cfg.spiComm.boot_spi_iface = tmc9660::bootcfg::SPIInterface::IFACE0; ///< Use SPI0
+
+    // Write the configuration to the device.
+    auto res = driver.bootloaderInit(&cfg);
+    if (res == TMC9660::BootloaderInitResult::Success)
+        std::cout << "Bootloader configured successfully" << std::endl;
+    else
+        std::cout << "Bootloader configuration failed" << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- clarify that examples rely on a user-implemented communication bus
- expand README usage instructions
- document DummyBus placeholder in HardwareAgnosticExamples
- add Doxygen comments and details to all example programs

## Testing
- ❌ `g++ -std=c++20 -Iinc src/TMC9660.cpp src/TMC9660Bootloader.cpp examples/bootloader_example.cpp -o /tmp/demo` (fails: redeclaration errors)


------
https://chatgpt.com/codex/tasks/task_e_6840b687a91c8328a976d273bcd66cca