### PR TITLE
Add indexed docs with navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,13 @@ in-depth walkthrough of each scenario is provided in
 `docs/HardwareAgnosticExamples.md`.
 
 ## 📖 Further Documentation
+Complete documentation is organized in [docs/index.md](docs/index.md). The major guides are listed below:
 * [docs/SetupGuide.md](docs/SetupGuide.md) – step-by-step setup and build instructions.
 * [docs/ImplementingCommInterface.md](docs/ImplementingCommInterface.md) – create your own transport layer.
 * [docs/BuildingExamples.md](docs/BuildingExamples.md) – compile and run the example programs.
+* [docs/HardwareAgnosticExamples.md](docs/HardwareAgnosticExamples.md) – detailed usage scenarios.
 * [docs/CommonOperations.md](docs/CommonOperations.md) – quick reference for typical driver calls.
+
 
 ## 🙌 Contributing
 Pull requests and feature ideas are welcome! Please format code with `clang-format` and sign off your commits.

--- a/docs/BuildingExamples.md
+++ b/docs/BuildingExamples.md
@@ -67,3 +67,7 @@ scripts once you have verified the commands above work on your system.
 When integrating into a larger project you will most likely add these
 source files to your existing `Makefile` or `CMakeLists.txt`.
 
+
+---
+
+[⬅️ Prev](ImplementingCommInterface.md) | [⬆️ Back to Index](index.md) | [Next ➡️](HardwareAgnosticExamples.md)

--- a/docs/CommonOperations.md
+++ b/docs/CommonOperations.md
@@ -60,3 +60,7 @@ Refer to `inc/TMC9660.hpp` for the complete API and additional helper
 functions. With these building blocks you can integrate the driver into your
 motion control software and start experimenting right away.
 
+
+---
+
+[⬅️ Prev](HardwareAgnosticExamples.md) | [⬆️ Back to Index](index.md)

--- a/docs/HardwareAgnosticExamples.md
+++ b/docs/HardwareAgnosticExamples.md
@@ -194,3 +194,7 @@ int main() {
 
 These snippets are minimal but cover the main features of the library. Refer to `inc/TMC9660.hpp` for all available parameters and helper methods.
 
+
+---
+
+[⬅️ Prev](BuildingExamples.md) | [⬆️ Back to Index](index.md) | [Next ➡️](CommonOperations.md)

--- a/docs/ImplementingCommInterface.md
+++ b/docs/ImplementingCommInterface.md
@@ -82,3 +82,7 @@ programs or integrate the driver into your own application:
 * Consider wrapping the driver in a small C API if your larger project is
   in C rather than C++.
 
+
+---
+
+[⬅️ Prev](SetupGuide.md) | [⬆️ Back to Index](index.md) | [Next ➡️](BuildingExamples.md)

--- a/docs/SetupGuide.md
+++ b/docs/SetupGuide.md
@@ -88,3 +88,7 @@ ready to drop into your own project.
 * Integrate the object files into your build system or create a small
   static library to reuse across multiple projects.
 
+
+---
+
+[⬅️ Prev](index.md) | [⬆️ Back to Index](index.md) | [Next ➡️](ImplementingCommInterface.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,14 @@
+# HF-TMC9660 Documentation Index
+
+Welcome to the extended documentation for the HF-TMC9660 driver library. The pages below are ordered to walk you from initial setup to advanced usage. Use the navigation links at the bottom of each page to move between sections.
+
+## Table of Contents
+1. [Setup Guide](SetupGuide.md)
+2. [Implementing a Communication Interface](ImplementingCommInterface.md)
+3. [Building and Running the Examples](BuildingExamples.md)
+4. [Hardware Agnostic Examples](HardwareAgnosticExamples.md)
+5. [Common Operations](CommonOperations.md)
+
+---
+
+[Next ➡️](SetupGuide.md)


### PR DESCRIPTION
## Summary
- add `docs/index.md` as documentation landing page
- link to `docs/index.md` from README
- add Prev/Next navigation links to all docs for easier reading
