### PR TITLE
Add ESP-IDF example and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,105 @@
+name: CI \u2022 Build \u00b7 Size \u00b7 Static Analyse
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IDF_TARGET: esp32c6
+  BUILD_PATH: ci_project
+  ESP_IDF_VERSIONS: '["release-v5.5"]'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build \u279c ${{ matrix.idf_version }} \u00b7 ${{ matrix.build_type }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        idf_version: [release-v5.5]
+        build_type: [Release, Debug]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y clang-format
+
+      - name: Format check
+        run: clang-format --dry-run --Werror src/*.cpp examples/esp32/main/*.cpp
+
+      - name: ESP-IDF build
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: ${{ matrix.idf_version }}
+          target: ${{ env.IDF_TARGET }}
+          path: .
+          command: |
+            idf.py create-project ${{ env.BUILD_PATH }}
+            cp examples/esp32/CMakeLists.txt ${{ env.BUILD_PATH }}/CMakeLists.txt
+            sed -i "s|../../components|../components|" ${{ env.BUILD_PATH }}/CMakeLists.txt
+            rm -rf ${{ env.BUILD_PATH }}/main
+            cp -r examples/esp32/main ${{ env.BUILD_PATH }}/main
+            cp -r examples/common ${{ env.BUILD_PATH }}/common
+            idf.py -C ${{ env.BUILD_PATH }} -DIDF_TARGET=${{ env.IDF_TARGET }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} build
+            idf.py -C ${{ env.BUILD_PATH }} size-components > ${{ env.BUILD_PATH }}/build/size.txt
+            idf.py -C ${{ env.BUILD_PATH }} size --format json > ${{ env.BUILD_PATH }}/build/size.json
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: fw-${{ matrix.idf_version }}-${{ matrix.build_type }}
+          retention-days: 14
+          path: |
+            ${{ env.BUILD_PATH }}/build/*.bin
+            ${{ env.BUILD_PATH }}/build/*.elf
+            ${{ env.BUILD_PATH }}/build/*.map
+            ${{ env.BUILD_PATH }}/build/size.*
+
+  static-analysis:
+    if: github.event_name == 'pull_request'
+    name: Static analyse (cppcheck + clang-tidy)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: deep5050/cppcheck-action@v3.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          enable: all
+          inconclusive: true
+          std: c99
+          include: main
+
+      - uses: ZedThree/clang-tidy-review@v0.21.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config_file: .clang-tidy
+
+  workflow-lint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/actionlint@v1.6.25

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignore JSON files
 *.json
 
-# Ignore dot-directories anywhere, except .git
+# Ignore dot-directories anywhere, except .git and .github
 **/.*/
-!/.git/
+!/.git
+!/.github/

--- a/components/hf_tmc9660/CMakeLists.txt
+++ b/components/hf_tmc9660/CMakeLists.txt
@@ -1,0 +1,9 @@
+idf_component_register(
+    SRCS
+        ../../src/TMC9660.cpp
+        ../../src/TMC9660Bootloader.cpp
+    INCLUDE_DIRS
+        ../../inc
+        ../../inc/register_mode
+        ../../inc/parameter_mode
+)

--- a/examples/common/dummy_bus.hpp
+++ b/examples/common/dummy_bus.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include <array>
+#include "TMC9660.hpp"
+
+class DummyBus : public SPITMC9660CommInterface {
+public:
+    bool spiTransfer(std::array<uint8_t,8>& tx, std::array<uint8_t,8>& rx) noexcept override {
+        rx = tx;
+        return true;
+    }
+};

--- a/examples/esp32/CMakeLists.txt
+++ b/examples/esp32/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.5)
+set(EXTRA_COMPONENT_DIRS ../../components)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(tmc9660_example)

--- a/examples/esp32/main/CMakeLists.txt
+++ b/examples/esp32/main/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "main.cpp"
+    INCLUDE_DIRS "." "../../common"
+    REQUIRES hf_tmc9660
+)

--- a/examples/esp32/main/main.cpp
+++ b/examples/esp32/main/main.cpp
@@ -1,0 +1,12 @@
+#include "TMC9660.hpp"
+#include "../../common/dummy_bus.hpp"
+
+extern "C" void app_main()
+{
+    DummyBus bus;
+    TMC9660 driver(bus);
+
+    driver.configureMotorType(TMC9660::MotorType::BLDC, 7);
+    driver.setCommutationMode(TMC9660::CommutationMode::FOC_HALL);
+    driver.setTargetVelocity(1000);
+}


### PR DESCRIPTION
## Summary
- add ESP-IDF component descriptor
- provide ESP32 sample app using the driver
- share DummyBus helper
- create workflow that builds the example with esp-idf
- update `.gitignore` to allow workflow files
