### PR TITLE
Fix ESP-IDF example include path

### DIFF
--- a/examples/esp32/main/CMakeLists.txt
+++ b/examples/esp32/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "main.cpp"
-    INCLUDE_DIRS "." "../../common"
+    INCLUDE_DIRS "." "../common"
     REQUIRES hf_tmc9660
 )


### PR DESCRIPTION
## Summary
- fix incorrect include path for `common` headers in ESP-IDF example
