### PR TITLE
Fix examples for updated TMC9660 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ This library centers around a single `TMC9660` class that communicates via an ab
 classDiagram
     direction LR
     class TMC9660 {
-        +configureMotorType()
-        +setTargetVelocity()
-        +getChipTemperature()
+        +motorConfig.setType()
+        +focControl.setTargetVelocity()
+        +telemetry.getChipTemperature()
     }
     TMC9660 --> TMC9660CommInterface : uses
 ```
@@ -115,9 +115,10 @@ g++ -std=c++20 -Iinc src/TMC9660.cpp examples/BLDC_with_HALL.cpp -o hall_demo
 DemoInterface bus;
 TMC9660 driver(bus);
 
-driver.configureMotorType(TMC9660::MotorType::BLDC, 7);
-driver.setCommutationMode(TMC9660::CommutationMode::FOC_HALL);
-driver.setTargetVelocity(1000);
+driver.motorConfig.setType(tmc9660::tmcl::MotorType::BLDC_MOTOR, 7);
+driver.motorConfig.setCommutationMode(
+    tmc9660::tmcl::CommutationMode::FOC_HALL_SENSOR);
+driver.focControl.setTargetVelocity(1000);
 ```
 Replace `DemoInterface` with your SPI or UART implementation to talk to real hardware.
 All API calls return a boolean status so you can handle communication errors if needed.

--- a/examples/BLDC_velocity_control.cpp
+++ b/examples/BLDC_velocity_control.cpp
@@ -23,31 +23,32 @@ int main() {
     TMC9660 driver(bus);
 
     // 1. Configure motor type as DC.
-    if (!driver.configureMotorType(TMC9660::MotorType::DC)) {
+    if (!driver.motorConfig.setType(tmc9660::tmcl::MotorType::DC_MOTOR)) {
         std::cerr << "Failed to configure DC motor type." << std::endl;
         return 1;
     }
 
     // 2. Set maximum current limit for the DC motor (e.g., 1500 mA).
-    driver.setMaxCurrent(1500);
+    driver.motorConfig.setMaxTorqueCurrent(1500);
 
     // 3. Configure an encoder for velocity feedback (e.g., 1024 counts per revolution).
-    driver.configureABNEncoder(1024);
+    driver.feedbackSense.configureABNEncoder(1024);
 
     // 4. For DC motor, use open-loop current mode to drive the H-bridge.
-    driver.setCommutationMode(TMC9660::CommutationMode::FOC_OPENLOOP_CURRENT);
+    driver.motorConfig.setCommutationMode(
+        tmc9660::tmcl::CommutationMode::FOC_OPENLOOP_CURRENT_MODE);
 
     // (Optional: tune velocity loop gains if necessary)
     // driver.setVelocityLoopGains(500, 5);
 
     // 5. Set a target velocity (requires encoder feedback for closed-loop speed control).
-    driver.setTargetVelocity(500);
+    driver.focControl.setTargetVelocity(500);
     std::cout << "DC motor running at target velocity 500 (internal units)." << std::endl;
 
     // ... (In a real application, the motor would accelerate to the target speed and maintain it) ...
 
     // 6. Stop the motor when done.
-    driver.stopMotor();
+    driver.focControl.stop();
     std::cout << "Motor stopped." << std::endl;
 
     return 0;

--- a/examples/BLDC_with_ABN.cpp
+++ b/examples/BLDC_with_ABN.cpp
@@ -25,13 +25,13 @@ int main() {
     TMC9660 driver(bus);    //!< Driver instance using that bus
 
     // Configure motor parameters
-    driver.motor.setType(tmc9660::tmcl::MotorType::BLDC_MOTOR, 7);
-    driver.motor.configureABNEncoder(2048); // 2048 line incremental encoder
-    driver.motor.setCommutationMode(
-        tmc9660::tmcl::CommutationMode::FOC_ENCODER); // use encoder based FOC
-    driver.motor.setMaxTorqueCurrent(2000); // limit phase current to 2 A
+    driver.motorConfig.setType(tmc9660::tmcl::MotorType::BLDC_MOTOR, 7);
+    driver.feedbackSense.configureABNEncoder(2048); // 2048 line incremental encoder
+    driver.motorConfig.setCommutationMode(
+        tmc9660::tmcl::CommutationMode::FOC_ABN); // use encoder based FOC
+    driver.motorConfig.setMaxTorqueCurrent(2000); // limit phase current to 2 A
 
     // Start rotating
-    driver.rampGenerator.setTargetVelocity(1000);
+    driver.focControl.setTargetVelocity(1000);
     std::cout << "BLDC motor running with ABN encoder" << std::endl;
 }

--- a/examples/BLDC_with_HALL.cpp
+++ b/examples/BLDC_with_HALL.cpp
@@ -24,39 +24,41 @@ int main() {
 
     // 1. Configure motor type as BLDC (3-phase) with specified pole pairs.
     uint8_t polePairs = 7;  // example pole pair count
-    if (!driver.configureMotorType(TMC9660::MotorType::BLDC, polePairs)) {
+    if (!driver.motorConfig.setType(tmc9660::tmcl::MotorType::BLDC_MOTOR,
+                                    polePairs)) {
         std::cerr << "Failed to set motor type!" << std::endl;
         return 1;
     }
 
     // 2. Configure Hall sensor feedback (assuming standard hall sequence, not inverted).
-    driver.configureHall();
+    driver.feedbackSense.configureHall();
 
     // 3. Set commutation mode to FOC with Hall feedback.
-    driver.setCommutationMode(TMC9660::CommutationMode::FOC_HALL);
+    driver.motorConfig.setCommutationMode(
+        tmc9660::tmcl::CommutationMode::FOC_HALL_SENSOR);
 
     // 4. Set maximum motor current (torque limit) to 2000 mA.
-    driver.setMaxCurrent(2000);
+    driver.motorConfig.setMaxTorqueCurrent(2000);
 
     // (Optional) Tune FOC control gains if necessary:
     // driver.setCurrentLoopGains(50, 100);       // example current PI gains
     // driver.setVelocityLoopGains(800, 1);       // example velocity PI gains
 
     // 5. Command a velocity. For example, target velocity = 1000 (internal units).
-    driver.setTargetVelocity(1000);
+    driver.focControl.setTargetVelocity(1000);
     std::cout << "Motor started with target velocity 1000." << std::endl;
 
     // ... Motor would now ramp up to the target speed and hold it ...
 
     // Simulate reading telemetry after some time:
-    float tempC = driver.getChipTemperature();
-    int16_t current_mA = driver.getMotorCurrent();
-    float busVolt = driver.getSupplyVoltage();
+    float tempC = driver.telemetry.getChipTemperature();
+    int16_t current_mA = driver.telemetry.getMotorCurrent();
+    float busVolt = driver.telemetry.getSupplyVoltage();
     std::cout << "Telemetry - Temp: " << tempC << " °C, Current: " 
               << current_mA << " mA, Bus Voltage: " << busVolt << " V" << std::endl;
 
     // 6. Stop the motor.
-    driver.stopMotor();
+    driver.focControl.stop();
     std::cout << "Motor stop command issued." << std::endl;
 
     return 0;

--- a/examples/DC_current_control.cpp
+++ b/examples/DC_current_control.cpp
@@ -24,11 +24,11 @@ int main() {
     TMC9660 driver(bus); //!< Driver communicating with the TMC9660
 
     // Configure motor and drive settings
-    driver.motor.setType(tmc9660::tmcl::MotorType::DC_MOTOR);
-    driver.motor.setCommutationMode(
-        tmc9660::tmcl::CommutationMode::FOC_OPENLOOP_CURRENT);
-    driver.motor.setMaxTorqueCurrent(1000);  // peak current in mA
-    driver.rampGenerator.setTargetCurrent(500); // hold 500 mA
+    driver.motorConfig.setType(tmc9660::tmcl::MotorType::DC_MOTOR);
+    driver.motorConfig.setCommutationMode(
+        tmc9660::tmcl::CommutationMode::FOC_OPENLOOP_CURRENT_MODE);
+    driver.motorConfig.setMaxTorqueCurrent(1000);  // peak current in mA
+    driver.focControl.setTargetTorque(500); // hold 500 mA
 
     std::cout << "DC motor current control active" << std::endl;
 }

--- a/examples/Stepper_FOC.cpp
+++ b/examples/Stepper_FOC.cpp
@@ -23,11 +23,11 @@ int main() {
     DummyBus bus;        //!< Replace with real bus
     TMC9660 driver(bus); //!< Motor driver instance
 
-    driver.motor.setType(tmc9660::tmcl::MotorType::STEPPER_MOTOR);
-    driver.motor.configureABNEncoder(4000);      // encoder resolution
-    driver.motor.setCommutationMode(
-        tmc9660::tmcl::CommutationMode::FOC_ENCODER);
+    driver.motorConfig.setType(tmc9660::tmcl::MotorType::STEPPER_MOTOR);
+    driver.feedbackSense.configureABNEncoder(4000);      // encoder resolution
+    driver.motorConfig.setCommutationMode(
+        tmc9660::tmcl::CommutationMode::FOC_ABN);
 
-    driver.position.moveTo(500);                 // command position
+    driver.focControl.setTargetPosition(500);                 // command position
     std::cout << "Stepper moving to position 500" << std::endl;
 }

--- a/examples/Stepper_step_dir.cpp
+++ b/examples/Stepper_step_dir.cpp
@@ -23,9 +23,9 @@ int main() {
     DummyBus bus;        //!< Replace with actual transport
     TMC9660 driver(bus); //!< Driver instance
 
-    driver.motor.setType(tmc9660::tmcl::MotorType::STEPPER_MOTOR);
+    driver.motorConfig.setType(tmc9660::tmcl::MotorType::STEPPER_MOTOR);
     driver.stepDir.setMicrostepResolution(
-        tmc9660::tmcl::StepDirStepDividerShift::DIV8);
+        tmc9660::tmcl::StepDirStepDividerShift::STEP_MODE_1_8TH);
     driver.stepDir.enableInterface(true);  // enable STEP/DIR pins
     driver.stepDir.enableExtrapolation(true); // smooth interpolation
 

--- a/examples/Telemetry_monitor.cpp
+++ b/examples/Telemetry_monitor.cpp
@@ -25,9 +25,9 @@ int main() {
 
     // Assume motor is configured and running. We will poll telemetry.
     for (int i = 0; i < 5; ++i) {
-        float chipTemp = driver.getChipTemperature();
-        int16_t motorCurrent = driver.getMotorCurrent();
-        float supplyVolt = driver.getSupplyVoltage();
+        float chipTemp = driver.telemetry.getChipTemperature();
+        int16_t motorCurrent = driver.telemetry.getMotorCurrent();
+        float supplyVolt = driver.telemetry.getSupplyVoltage();
         std::cout << "Read " << i+1 << ": Temp = " << chipTemp << " °C, "
                   << "Current = " << motorCurrent << " mA, "
                   << "Voltage = " << supplyVolt << " V" << std::endl;

--- a/examples/esp32/main/main.cpp
+++ b/examples/esp32/main/main.cpp
@@ -5,7 +5,8 @@ extern "C" void app_main() {
   DummyBus bus;
   TMC9660 driver(bus);
 
-  driver.configureMotorType(TMC9660::MotorType::BLDC, 7);
-  driver.setCommutationMode(TMC9660::CommutationMode::FOC_HALL);
-  driver.setTargetVelocity(1000);
+  driver.motorConfig.setType(tmc9660::tmcl::MotorType::BLDC_MOTOR, 7);
+  driver.motorConfig.setCommutationMode(
+      tmc9660::tmcl::CommutationMode::FOC_HALL_SENSOR);
+  driver.focControl.setTargetVelocity(1000);
 }


### PR DESCRIPTION
## Summary
- update examples to use the current public API names
- adjust README snippets and diagram accordingly
