### PR TITLE
Move component dir into esp32 example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,9 @@ jobs:
           command: |
             idf.py create-project ${{ env.BUILD_PATH }}
             cp examples/esp32/CMakeLists.txt ${{ env.BUILD_PATH }}/CMakeLists.txt
-            sed -i "s|../../components|../components|" ${{ env.BUILD_PATH }}/CMakeLists.txt
             rm -rf ${{ env.BUILD_PATH }}/main
             cp -r examples/esp32/main ${{ env.BUILD_PATH }}/main
+            cp -r examples/esp32/components ${{ env.BUILD_PATH }}/components
             cp -r examples/common ${{ env.BUILD_PATH }}/common
             idf.py -C ${{ env.BUILD_PATH }} -DIDF_TARGET=${{ env.IDF_TARGET }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} build
             idf.py -C ${{ env.BUILD_PATH }} size-components > ${{ env.BUILD_PATH }}/build/size.txt

--- a/components/hf_tmc9660/CMakeLists.txt
+++ b/components/hf_tmc9660/CMakeLists.txt
@@ -1,9 +1,0 @@
-idf_component_register(
-    SRCS
-        ../../src/TMC9660.cpp
-        ../../src/TMC9660Bootloader.cpp
-    INCLUDE_DIRS
-        ../../inc
-        ../../inc/register_mode
-        ../../inc/parameter_mode
-)

--- a/examples/esp32/CMakeLists.txt
+++ b/examples/esp32/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 3.5)
-set(EXTRA_COMPONENT_DIRS ../../components)
+set(EXTRA_COMPONENT_DIRS components)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(tmc9660_example)

--- a/examples/esp32/components/hf_tmc9660/CMakeLists.txt
+++ b/examples/esp32/components/hf_tmc9660/CMakeLists.txt
@@ -1,0 +1,9 @@
+idf_component_register(
+    SRCS
+        ../../../../src/TMC9660.cpp
+        ../../../../src/TMC9660Bootloader.cpp
+    INCLUDE_DIRS
+        ../../../../inc
+        ../../../../inc/register_mode
+        ../../../../inc/parameter_mode
+)


### PR DESCRIPTION
## Summary
- move `components/hf_tmc9660` into `examples/esp32/components`
- update ESP-IDF example CMake files
- modify CI workflow to copy component directory

## Testing
- `clang-format --dry-run --Werror src/*.cpp examples/esp32/main/*.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6850448858888328bb8334717c04ff41