### PR TITLE
Add GitHub Pages deployment guide

### DIFF
--- a/docs/CommonOperations.md
+++ b/docs/CommonOperations.md
@@ -63,4 +63,4 @@ motion control software and start experimenting right away.
 
 ---
 
-[⬅️ Prev](HardwareAgnosticExamples.md) | [⬆️ Back to Index](index.md)
+[⬅️ Prev](HardwareAgnosticExamples.md) | [⬆️ Back to Index](index.md) | [Next ➡️](HostingDocsWithGitHubPages.md)

--- a/docs/HostingDocsWithGitHubPages.md
+++ b/docs/HostingDocsWithGitHubPages.md
@@ -1,0 +1,28 @@
+# Hosting Documentation with GitHub Pages
+
+Automatically publishing the generated Doxygen output keeps the online documentation up to date. The repository includes a workflow that builds the HTML files and deploys them to GitHub Pages.
+
+## Workflow Snippet
+
+```yaml
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+steps:
+  - uses: actions/checkout@v4
+  - name: Build documentation
+    run: doxygen Doxyfile
+  - name: Deploy to GitHub Pages
+    uses: peaceiris/actions-gh-pages@v3
+    with:
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+      publish_dir: docs/html
+```
+
+If the step fails with a `403` error, the token lacks permission to push to the repository. Enable **Read and write permissions** under **Settings → Actions → General**, or provide a Personal Access Token with the `repo` scope and reference it as `${{ secrets.PAT }}`.
+
+---
+
+[\u2B05\uFE0F Prev](CommonOperations.md) | [\u2B06\uFE0F Back to Index](index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Welcome to the extended documentation for the HF-TMC9660 driver library. The pag
 3. [Building and Running the Examples](BuildingExamples.md)
 4. [Hardware Agnostic Examples](HardwareAgnosticExamples.md)
 5. [Common Operations](CommonOperations.md)
+6. [Hosting Documentation with GitHub Pages](HostingDocsWithGitHubPages.md)
 
 ---
 


### PR DESCRIPTION
## Summary
- document how to publish docs using GitHub Pages
- link new doc from index
- update navigation in `CommonOperations.md`
