### PR TITLE
Improve GitHub Pages docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,13 +33,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: docs-html
-          path: docs/html
+          path: docs
           retention-days: 7
       - name: Upload Pages artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/html
+          path: docs
 
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/docs/HostingDocsWithGitHubPages.md
+++ b/docs/HostingDocsWithGitHubPages.md
@@ -2,6 +2,11 @@
 
 Automatically publishing the generated Doxygen output keeps the online documentation up to date. The repository includes a workflow that builds the HTML files and deploys them to GitHub Pages.
 
+The Markdown guides under `docs/` form the written tutorial while Doxygen
+generates the C++ API reference in `docs/html`. Deploying the entire `docs`
+directory lets `index.md` act as the landing page with a complete table of
+contents. The API reference is then available at the `html/` subfolder.
+
 ## Workflow Snippet
 
 ```yaml
@@ -18,10 +23,14 @@ steps:
     uses: peaceiris/actions-gh-pages@v3
     with:
       github_token: ${{ secrets.GITHUB_TOKEN }}
-      publish_dir: docs/html
+      publish_dir: docs
 ```
 
 If the step fails with a `403` error, the token lacks permission to push to the repository. Enable **Read and write permissions** under **Settings → Actions → General**, or provide a Personal Access Token with the `repo` scope and reference it as `${{ secrets.PAT }}`.
+
+After pushing to `main`, visit **Settings → Pages** to find the deployed site.
+You should see the table of contents from `docs/index.md` and a link to the API
+reference in the `html/` directory.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Welcome to the extended documentation for the HF-TMC9660 driver library. The pag
 4. [Hardware Agnostic Examples](HardwareAgnosticExamples.md)
 5. [Common Operations](CommonOperations.md)
 6. [Hosting Documentation with GitHub Pages](HostingDocsWithGitHubPages.md)
+7. [C++ API Reference](html/index.html)
 
 ---
 


### PR DESCRIPTION
## Summary
- link to Doxygen API in docs index
- explain workflow in `HostingDocsWithGitHubPages.md`
- publish entire `docs` folder in docs workflow

## Testing
- `doxygen Doxyfile`

------
https://chatgpt.com/codex/tasks/task_e_685ddd9a2b108328b2cdd63f2659fee3