### PR TITLE
Fix docs link for Doxygen

### DIFF
--- a/docs/annotated.html
+++ b/docs/annotated.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=html/annotated.html" />
+    <title>HF-TMC9660 API Reference</title>
+  </head>
+  <body>
+    <p>If you are not redirected automatically, follow this <a href="html/annotated.html">link to the API reference</a>.</p>
+  </body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,8 +5,8 @@
     <title>HF-TMC9660 Documentation</title>
 </head>
 <body>
-<h1>HF-TMC9660 Documentation Index</h1>
-<p>Welcome to the extended documentation for the HF-TMC9660 driver library. The pages below are ordered to walk you from initial setup to advanced usage.</p>
+<h1>HF-TMC9660 Documentation</h1>
+<p>Welcome to the home of the HF-TMC9660 driver docs. The pages are intended to be read sequentially—start with the setup guide and work your way through. Each section links to the next so you can easily navigate.</p>
 <ol>
 <li><a href="SetupGuide.md">Setup Guide</a></li>
 <li><a href="ImplementingCommInterface.md">Implementing a Communication Interface</a></li>
@@ -17,6 +17,6 @@
 <li><a href="html/index.html">C++ API Reference</a></li>
 </ol>
 <hr>
-<p><a href="SetupGuide.md">Next ➡️</a></p>
+<p>Start with the <a href="SetupGuide.md">Setup Guide</a> to prepare your environment.</p>
 </body>
 </html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,9 @@
-# HF-TMC9660 Documentation Index
+# HF-TMC9660 Documentation
 
-Welcome to the extended documentation for the HF-TMC9660 driver library. The pages below are ordered to walk you from initial setup to advanced usage. Use the navigation links at the bottom of each page to move between sections.
+Welcome to the home of the HF-TMC9660 driver docs. This guide is meant to be read
+in order—the links below will walk you through initial setup and on to more
+advanced topics. Each page ends with navigation controls so you can easily move
+back and forth.
 
 ## Table of Contents
 1. [Setup Guide](SetupGuide.md)
@@ -9,8 +12,10 @@ Welcome to the extended documentation for the HF-TMC9660 driver library. The pag
 4. [Hardware Agnostic Examples](HardwareAgnosticExamples.md)
 5. [Common Operations](CommonOperations.md)
 6. [Hosting Documentation with GitHub Pages](HostingDocsWithGitHubPages.md)
-7. [C++ API Reference](html/index.html)
+7. [C++ API Reference](annotated.html)
 
 ---
+
+Start with the **Setup Guide** to get the environment ready.
 
 [Next ➡️](SetupGuide.md)


### PR DESCRIPTION
## Summary
- restore `docs/index.md` as the main Doxygen page
- keep `docs/index.md` in the documentation input
- update the landing page content and link to the API reference
- add a redirect page `docs/annotated.html` so the API link resolves

## Testing
- `doxygen Doxyfile`
- `lychee --no-progress --exclude "https://www.doxygen.org" docs docs/html`


------
https://chatgpt.com/codex/tasks/task_e_685decb49fa0832895a80de04d6ee648