### PR TITLE
Fix documentation links

### DIFF
--- a/docs/BuildingExamples.md
+++ b/docs/BuildingExamples.md
@@ -75,4 +75,4 @@ source files to your existing `Makefile` or `CMakeLists.txt`.
 
 ---
 
-[⬅️ Prev](ImplementingCommInterface.md) | [⬆️ Back to Index](index.md) | [Next ➡️](HardwareAgnosticExamples.md)
+[⬅️ Prev](ImplementingCommInterface.html) | [⬆️ Back to Index](index.html) | [Next ➡️](HardwareAgnosticExamples.html)

--- a/docs/CommonOperations.md
+++ b/docs/CommonOperations.md
@@ -68,4 +68,4 @@ motion control software and start experimenting right away.
 
 ---
 
-[⬅️ Prev](HardwareAgnosticExamples.md) | [⬆️ Back to Index](index.md) | [Next ➡️](HostingDocsWithGitHubPages.md)
+[⬅️ Prev](HardwareAgnosticExamples.html) | [⬆️ Back to Index](index.html) | [Next ➡️](HostingDocsWithGitHubPages.html)

--- a/docs/HardwareAgnosticExamples.md
+++ b/docs/HardwareAgnosticExamples.md
@@ -202,4 +202,4 @@ These snippets are minimal but cover the main features of the library. Refer to 
 
 ---
 
-[⬅️ Prev](BuildingExamples.md) | [⬆️ Back to Index](index.md) | [Next ➡️](CommonOperations.md)
+[⬅️ Prev](BuildingExamples.html) | [⬆️ Back to Index](index.html) | [Next ➡️](CommonOperations.html)

--- a/docs/HostingDocsWithGitHubPages.md
+++ b/docs/HostingDocsWithGitHubPages.md
@@ -47,4 +47,4 @@ reference in the `html/` directory.
 
 ---
 
-[\u2B05\uFE0F Prev](CommonOperations.md) | [\u2B06\uFE0F Back to Index](index.md)
+[\u2B05\uFE0F Prev](CommonOperations.html) | [\u2B06\uFE0F Back to Index](index.html)

--- a/docs/ImplementingCommInterface.md
+++ b/docs/ImplementingCommInterface.md
@@ -81,7 +81,7 @@ All library calls now communicate through your implementation.
 After implementing the interface you can build any of the example
 programs or integrate the driver into your own application:
 
-* Compile one of the demos from [BuildingExamples.md](BuildingExamples.md)
+* Compile one of the demos from [BuildingExamples.md](BuildingExamples.html)
   to verify transfers work.
 * Hook the `TMC9660` object into your existing control loop or RTOS task.
 * Consider wrapping the driver in a small C API if your larger project is
@@ -90,4 +90,4 @@ programs or integrate the driver into your own application:
 
 ---
 
-[⬅️ Prev](SetupGuide.md) | [⬆️ Back to Index](index.md) | [Next ➡️](BuildingExamples.md)
+[⬅️ Prev](SetupGuide.html) | [⬆️ Back to Index](index.html) | [Next ➡️](BuildingExamples.html)

--- a/docs/SetupGuide.md
+++ b/docs/SetupGuide.md
@@ -88,12 +88,12 @@ ready to drop into your own project.
 ## 5. Next Steps
 
 * Implement a custom communication interface as described in
-  [ImplementingCommInterface.md](ImplementingCommInterface.md).
-* Explore the full examples in [HardwareAgnosticExamples.md](HardwareAgnosticExamples.md).
+  [ImplementingCommInterface.md](ImplementingCommInterface.html).
+* Explore the full examples in [HardwareAgnosticExamples.md](HardwareAgnosticExamples.html).
 * Integrate the object files into your build system or create a small
   static library to reuse across multiple projects.
 
 
 ---
 
-[⬅️ Prev](index.md) | [⬆️ Back to Index](index.md) | [Next ➡️](ImplementingCommInterface.md)
+[⬅️ Prev](index.html) | [⬆️ Back to Index](index.html) | [Next ➡️](ImplementingCommInterface.html)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,16 +11,16 @@ advanced topics. Each page ends with navigation controls so you can easily move
 back and forth.
 
 ## Table of Contents
-1. [Setup Guide](SetupGuide.md)
-2. [Implementing a Communication Interface](ImplementingCommInterface.md)
-3. [Building and Running the Examples](BuildingExamples.md)
-4. [Hardware Agnostic Examples](HardwareAgnosticExamples.md)
-5. [Common Operations](CommonOperations.md)
-6. [Hosting Documentation with GitHub Pages](HostingDocsWithGitHubPages.md)
+1. [Setup Guide](SetupGuide.html)
+2. [Implementing a Communication Interface](ImplementingCommInterface.html)
+3. [Building and Running the Examples](BuildingExamples.html)
+4. [Hardware Agnostic Examples](HardwareAgnosticExamples.html)
+5. [Common Operations](CommonOperations.html)
+6. [Hosting Documentation with GitHub Pages](HostingDocsWithGitHubPages.html)
 7. [C++ API Reference](annotated.html)
 
 ---
 
 Start with the **Setup Guide** to get the environment ready.
 
-[Next ➡️](SetupGuide.md)
+[Next ➡️](SetupGuide.html)


### PR DESCRIPTION
## Summary
- fix all internal markdown links in documentation to use `.html`

## Testing
- `jekyll build --source docs --destination _site`
- `./lychee --no-progress _site | head -n 20`
