### PR TITLE
Fix Docs workflow guidance

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,4 @@
+---
 name: Docs
 
 on:
@@ -25,11 +26,17 @@ jobs:
         id: pages
         uses: actions/configure-pages@v4
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y doxygen graphviz ruby-full && sudo gem install jekyll jekyll-theme-slate
-      - name: Build documentation
         run: |
-          doxygen Doxyfile
-          ruby -S jekyll build --source docs --destination _site --baseurl "${{ steps.pages.outputs.base_path }}"
+          sudo apt-get update
+          sudo apt-get install -y doxygen graphviz ruby-full
+          sudo gem install jekyll jekyll-theme-slate
+      - name: Build documentation
+          run: |
+            doxygen Doxyfile
+            ruby -S jekyll build \
+              --source docs \
+              --destination _site \
+              --baseurl "${{ steps.pages.outputs.base_path }}"
       - name: Link check
         uses: lycheeverse/lychee-action@v2
         with:

--- a/docs/HostingDocsWithGitHubPages.md
+++ b/docs/HostingDocsWithGitHubPages.md
@@ -39,6 +39,11 @@ steps:
     uses: actions/deploy-pages@v4
 ```
 
+This method avoids creating commits on a dedicated `gh-pages` branch. The
+`deploy-pages` action uploads the static files directly to the Pages
+infrastructure, so the workflow works even if the default `GITHUB_TOKEN` only
+has read access to the repository.
+
 If the step fails with a `403` error, the token lacks permission to push to the repository. Enable **Read and write permissions** under **Settings → Actions → General**, or provide a Personal Access Token with the `repo` scope and reference it as `${{ secrets.PAT }}`.
 
 After pushing to `main`, visit **Settings → Pages** to find the deployed site.


### PR DESCRIPTION
## Summary
- clarify README on using deploy-pages with built-in token
- break long commands in docs workflow and add `---`
