### PR TITLE
Fix YAML formatting in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,12 +31,12 @@ jobs:
           sudo apt-get install -y doxygen graphviz ruby-full
           sudo gem install jekyll jekyll-theme-slate
       - name: Build documentation
-          run: |
-            doxygen Doxyfile
-            ruby -S jekyll build \
-              --source docs \
-              --destination _site \
-              --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: |
+          doxygen Doxyfile
+          ruby -S jekyll build \
+            --source docs \
+            --destination _site \
+            --baseurl "${{ steps.pages.outputs.base_path }}"
       - name: Link check
         uses: lycheeverse/lychee-action@v2
         with:


### PR DESCRIPTION
## Summary
- fix indentation of the `Build documentation` step in docs workflow
