### PR TITLE
Fix local link check by excluding docs from doxygen

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -943,7 +943,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = src inc docs
+INPUT                  = src inc
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -986,8 +986,7 @@ INPUT_FILE_ENCODING    =
 FILE_PATTERNS          = *.c \
                          *.cpp \
                          *.h \
-                         *.hpp \
-                         *.md
+                         *.hpp
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.
@@ -1113,7 +1112,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = docs/index.md
+USE_MDFILE_AS_MAINPAGE =
 
 # The Fortran standard specifies that for fixed formatted Fortran code all
 # characters from position 72 are to be considered as comment. A common


### PR DESCRIPTION
## Summary
- prevent Doxygen from processing docs markdown
- drop `USE_MDFILE_AS_MAINPAGE`

## Testing
- `doxygen Doxyfile`
- `ruby -S jekyll build --source docs --destination _site --baseurl ""`
- `/tmp/lychee --offline _site`